### PR TITLE
T044/T045/T047: v0.2.0 documentation updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,131 @@
+# Changelog
+
+All notable changes to this project are documented here. See [CONTRIBUTING.md](./CONTRIBUTING.md) for release and versioning information.
+
+---
+
+## [v0.2.0] - 2025-07-30
+
+### Bug Fixes
+
+- **Hook Deployment:** Fixed missing hook script deployment in `.specify/extensions/squad-speckit-bridge/hooks/`. The installer now correctly copies `after-tasks.sh`, `before-specify.sh`, and `after-implement.sh` with executable permissions. Existing installations should re-run `install` to add missing hooks. *(Fixes US1, #101)*
+
+- **Spec Kit Extension Model Alignment:** Fixed `extension.yml` manifest to conform exactly to Spec Kit's extension schema. Hooks are now correctly discovered and invoked by Spec Kit during lifecycle events. *(Fixes US2, #102)*
+
+- **CLI Contract Gaps:** Added missing CLI contract definitions for `--verbose`, `--notify`, and `--dry-run` flags across all commands. These flags were documented but not implemented in v0.1.0. *(Fixes #103)*
+
+### New Features
+
+- **`issues` Command (v0.2.0):** Convert approved `tasks.md` into GitHub issues with a single command.
+  - `npx @jmservera/squad-speckit-bridge issues <tasks-file>` — Creates one issue per task with proper labels and dependency references
+  - `--dry-run` — Preview issues before creating (recommended safety check)
+  - `--labels <list>` — Add custom labels (e.g., `--labels priority/high,team/backend`)
+  - `--json` — Machine-readable output for CI/CD integration
+  - *(Implements US3)*
+
+- **`sync` Command (v0.2.0):** Capture Squad execution learnings and mark them for the next planning cycle.
+  - `npx @jmservera/squad-speckit-bridge sync` — Records new decisions and learnings from Squad agents
+  - `--dry-run` — Preview what would be synced without modifying
+  - `--since <timestamp>` — Sync changes after a specific point in time
+  - `--json` — Machine-readable output
+  - Closes the knowledge loop: Squad memory → planning → execution → learnings → back to Squad
+  - *(Implements US4)*
+
+- **Automation Hooks (v0.2.0):** New hooks to reduce manual workflow steps.
+  - `before_specify` — Auto-injects Squad context before planning starts (no manual `context` command needed)
+  - `after_implement` — Auto-captures execution learnings after Spec Kit implements (no manual `sync` command needed)
+  - Both hooks are optional and configurable via `bridge.config.json`
+  - *(Implements US5)*
+
+### Improvements
+
+- **Enhanced `context` Command:** Added flags to support production workflows.
+  - `--verbose` — Show detailed processing (file paths, budget breakdown, item selection logic)
+  - `--notify` — Send status notifications to Squad agents (requires `notifications.enabled: true` in config)
+  - Output now shows context quality metrics and processing details
+
+- **Enhanced `status` Command:** Now reports comprehensive bridge health including hook deployment status, constitution customization, and last sync timestamp.
+  - `--verbose` — Shows file paths, permission checks, and detailed hook state
+  - Reports if Squad constitution is using template (uncustomized) and recommends customization
+
+- **Constitution Detection (v0.2.0):** `status` command now warns if Squad constitution template is uncustomized (contains placeholder markers). Reminds teams to personalize their principles.
+
+- **Enhanced `issues` Command Output:** Shows created issue numbers, URLs, and phase labels. JSON output includes full issue details for scripting.
+
+- **Package Naming Clarification:** All documentation updated to use correct scoped package name: `@jmservera/squad-speckit-bridge` (npm publish as scoped package for clarity and namespace management).
+
+- **Improved Error Messages:** Error messages now include specific remediation steps and config examples, reducing support burden.
+
+### Documentation
+
+- **README.md:** Updated with v0.2.0 features, new command overview, automation hooks, and installation using scoped package name
+- **docs/usage.md:** Comprehensive update with:
+  - New `issues` and `sync` command documentation with copy-pasteable examples
+  - 6 common workflows (automatic, manual control, dry-run preview, CI/CD, context testing, verbose debugging)
+  - v0.2.0 configuration options (issues labels, sync state, notifications)
+  - Complete `--verbose` and `--notify` flag documentation
+  - Enhanced error handling table with GitHub auth and task file validation errors
+- **CHANGELOG.md:** Created (this file)
+
+---
+
+## [v0.1.0] - 2025-07-23
+
+### Initial Release
+
+Squad-SpecKit Bridge v0.1.0 establishes the core memory injection and design review workflow.
+
+### Features
+
+- **`install` Command:** Deploy bridge components (Squad skill, ceremony definitions, Spec Kit extension manifest, configuration file)
+
+- **`context` Command:** Manually generate and inject Squad memory context into Spec Kit planning phases
+  - Reads Squad decisions, learnings, and skills
+  - Applies relevance scoring and recency bias
+  - Respects configurable context budget (default: 8KB)
+  - Produces `squad-context.md` for Spec Kit planning phases
+
+- **`review` Command:** Manually generate Design Review templates with pre-populated findings
+  - Analyzes task conflicts and dependencies
+  - Flags potential risk areas
+  - Creates `review.md` for team discussion
+
+- **`status` Command:** Check bridge health and verify installation
+  - Detects Squad and Spec Kit presence
+  - Verifies component deployment
+  - Shows configuration state and last context run timestamp
+
+- **Automation Hook (`after_tasks`):** Automatically generates Design Reviews when Spec Kit completes task breakdown
+  - No manual command needed
+  - Optional, can be disabled via configuration
+
+- **Squad Plugin (SKILL.md):** Teaches agents about Spec Kit workflow and Design Review participation
+
+- **Clean Architecture:** Core logic organized into entities, use cases, adapters, and frameworks for testability and maintainability
+
+### Configuration
+
+- **bridge.config.json:** User-customizable settings for context budget, sources, summarization, hooks, and paths
+
+---
+
+## Versioning
+
+This project follows [Semantic Versioning](https://semver.org/):
+
+- **PATCH version** (0.0.x) — Bug fixes and documentation
+- **MINOR version** (0.x.0) — New features, backward-compatible
+- **MAJOR version** (x.0.0) — Breaking changes
+
+Current status: **v0.2.0** — Early development, APIs may change. First stable release planned for v1.0.0.
+
+---
+
+## How to Read This Changelog
+
+- **Bug Fixes** — Corrections to documented behavior or security issues
+- **New Features** — Additions that enable new workflows
+- **Improvements** — Enhancements to existing features (performance, UX, diagnostics)
+- **Documentation** — Updates to README, guides, and inline documentation
+
+All changes reference corresponding user stories (US1, US2, etc.) and GitHub issues for full context.

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ The bridge creates files that are part of your feature's planning record. Commit
 | `.bridge-manifest.json` | repo root | Tracks bridge version and installed components |
 | `.squad/skills/speckit-bridge/SKILL.md` | .squad/ | Teaches agents about Spec Kit artifacts and Design Review workflow |
 | `.squad/ceremonies/design-review.md` | .squad/ | Ceremony definition for Design Review process |
-| `.specify/extensions/squad-bridge/extension.yml` | .specify/ | Hook definitions for automation |
+| `.specify/extensions/squad-speckit-bridge/extension.yml` | .specify/ | Hook definitions for automation (includes before_specify, after_tasks, after_implement) |
 | `bridge.config.json` | repo root | Configuration file (customizable) |
 
 ### Created during workflow (also commit these):
@@ -91,8 +91,21 @@ After `/speckit.tasks`, a review template is auto-generated with pre-populated f
 ### 📝 Squad Plugin (SKILL.md)
 Teaches Squad agents about Spec Kit artifacts, methodology, and Design Review participation. Makes the team "bilingual" across both frameworks.
 
-### 🪝 Spec Kit Extension (after_tasks Hook)
-Auto-triggers Design Review generation when Spec Kit finishes task breakdown. No manual steps needed.
+### 🪝 Automation Hooks
+- `after_tasks` — Auto-generates Design Reviews when tasks complete (v0.1+)
+- `before_specify` — Auto-injects Squad context before planning (v0.2+)
+- `after_implement` — Auto-syncs execution learnings back to Squad (v0.2+)
+
+All hooks are optional and can be disabled via configuration.
+
+### 🎯 Issues & Sync Commands (v0.2+)
+- `issues` — Convert approved tasks into GitHub issues with one command (`--dry-run`, `--labels`, `--json` flags)
+- `sync` — Capture execution learnings from Squad history back into memory bridge for next planning cycle
+
+### 📊 Enhanced Diagnostics (v0.2+)
+- `--verbose` — Detailed output including file paths and processing details
+- `--notify` — Send bridge status notifications to Squad agents
+- Constitution detection — Warns if Squad constitution template is uncustomized
 
 ### 🏗️ Clean Architecture
 All core logic separated by dependency inversion. Easy to test, extend, and maintain independently of both frameworks.
@@ -101,14 +114,23 @@ All core logic separated by dependency inversion. Easy to test, extend, and main
 
 ## Quick Start
 
-> **Status:** 🚧 In Development — spec and plan complete, implementation pending
-
 ```bash
-# Coming soon (placeholder)
-npx squad-speckit-bridge init
+# One-time installation (deploys hooks and configuration)
+npx @jmservera/squad-speckit-bridge install
+
+# Use Spec Kit normally — bridge handles memory injection & reviews automatically
+cd specs/001-feature/
+/speckit.specify && /speckit.plan && /speckit.tasks
+
+# Team reviews the generated review.md
+# Once approved, create GitHub issues
+npx @jmservera/squad-speckit-bridge issues specs/001-feature/tasks.md
+
+# After Squad executes and learns, sync knowledge back (optional, v0.2+)
+npx @jmservera/squad-speckit-bridge sync
 ```
 
-For now, see [Installation & Usage](./docs/INSTALLATION.md) for manual setup.
+See [Usage Guide](./docs/usage.md) for complete workflows, advanced options, and manual command reference.
 
 ---
 
@@ -163,15 +185,17 @@ For now, see [Installation & Usage](./docs/INSTALLATION.md) for manual setup.
 
 ## Project Status
 
-**🚧 In Development**
+**v0.2.0 — In Development**
 
-- ✅ Research and validation complete
-- ✅ Feature specification written
-- ✅ Team decisions documented
-- ✅ Architecture designed (Clean Architecture layers)
-- ⏳ Implementation pending
+- ✅ v0.1.0 shipped (context, review, status commands; after_tasks hook)
+- ✅ v0.2.0 spec and plan complete
+- ✅ Bug fixes: hook deployment, extension model alignment
+- ✅ New commands: issues, sync
+- ✅ New hooks: before_specify, after_implement
+- ⏳ v0.2.0 implementation in progress
 
-See [Feature Spec](./specs/001-squad-speckit-bridge/spec.md) for detailed requirements.
+See [Feature Spec](./specs/001-squad-speckit-bridge/spec.md) for v0.1.0 details.  
+See [v0.2.0 Roadmap](./specs/002-v02-fixes-automation/spec.md) for upcoming features.
 
 ---
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -11,11 +11,11 @@ The bridge is **automation-first**. After installation, most work happens automa
 **Most teams never run manual commands.** This is what normally happens:
 
 ```bash
-# Step 1: One-time installation
-$ npx squad-speckit-bridge install
-# Result: Bridge components deployed. That's it.
+# Step 1: One-time installation (v0.1+)
+$ npx @jmservera/squad-speckit-bridge install
+# Result: Bridge components deployed, automation hooks installed
 
-# Step 2: Use Spec Kit normally
+# Step 2: Use Spec Kit normally (Squad context auto-injected)
 $ cd specs/001-feature/
 $ /speckit.specify && /speckit.plan && /speckit.tasks
 # Automatic: memory injection + review generation
@@ -24,9 +24,12 @@ $ /speckit.specify && /speckit.plan && /speckit.tasks
 # Open: specs/001-feature/review.md
 # Approve when ready.
 
-# Step 4: Create issues
-$ npx squad-speckit-bridge issues specs/001-feature/tasks.md
-# Result: GitHub issues created (labeled, assigned)
+# Step 4: Create issues (v0.2+)
+$ npx @jmservera/squad-speckit-bridge issues specs/001-feature/tasks.md
+# Result: GitHub issues created with labels and dependencies
+
+# Step 5 (optional): Sync learnings back after execution (v0.2+)
+$ npx @jmservera/squad-speckit-bridge sync
 ```
 
 That's the normal flow. Everything else below is for advanced use cases.
@@ -41,14 +44,14 @@ The bridge operates **silently in the background**. You'll see it work through g
 
 | File | Created When | Contains | Your Action |
 |------|--------------|----------|-------------|
-| `squad-context.md` | Before or during planning | Team decisions + learnings (budgeted summary) | Reference during planning; commit with code |
+| `squad-context.md` | Before/during planning | Team decisions + learnings (budgeted summary) | Reference during planning; commit with code |
 | `review.md` | After `/speckit.tasks` | Conflict flags + risk findings | Discuss with team; approve or annotate |
 
 **Commit both files.** They document the planning decisions and team review that informed execution.
 
 ### Automatic: Memory Injection (During Planning)
 
-**When:** Before Spec Kit planning runs (or on-demand via `context` command)  
+**When:** Before Spec Kit planning runs (v0.2+ via `before_specify` hook, or on-demand via `context` command)  
 **What:** Bridge reads `.squad/` (decisions, learnings, skills) and creates `squad-context.md`  
 **You see:** Planning context includes your team's experience; better task generation  
 **File created:** `specs/YOUR-SPEC/squad-context.md` (available for reference during planning)  
@@ -56,7 +59,7 @@ The bridge operates **silently in the background**. You'll see it work through g
 
 ### Automatic: Design Review Generation (After Tasks)
 
-**When:** Immediately after `/speckit.tasks` completes  
+**When:** Immediately after `/speckit.tasks` completes (via `after_tasks` hook)  
 **What:** Bridge analyzes tasks and generates a review template with pre-populated findings  
 **You see:**
 - `specs/YOUR-SPEC/review.md` with conflict flags and risk highlights
@@ -65,6 +68,14 @@ The bridge operates **silently in the background**. You'll see it work through g
 **What you do:** Open the review with your team, discuss findings, approve when satisfied  
 **File created:** `specs/YOUR-SPEC/review.md` (commit this with code)  
 **Config:** Can be disabled via `bridge.config.json` → `hooks.afterTasks: false`
+
+### Automatic: Execution Learning Sync (After Implementation, v0.2+)
+
+**When:** After Spec Kit's implement phase completes (via `after_implement` hook, or manual `sync` command)  
+**What:** Bridge captures new Squad decisions and learnings and marks them for next planning cycle  
+**You see:** Sync record with count of new decisions and learnings  
+**Result:** Next planning cycle's context includes this execution's learnings  
+**Config:** Can be disabled via `bridge.config.json` → `hooks.afterImplement: false`
 
 ### Automatic: Context Budget Management
 
@@ -82,7 +93,7 @@ The bridge respects a configurable context size limit (default: 8KB). Recent and
 Override the automatic context injection or run it independently.
 
 ```bash
-$ npx squad-speckit-bridge context specs/001-feature/
+$ npx @jmservera/squad-speckit-bridge context specs/001-feature/
 ```
 
 **Expected output:**
@@ -101,6 +112,8 @@ Output: specs/001-feature/squad-context.md (7.7KB / 8.0KB limit)
 - `--max-size <bytes>` — Override context budget (default: 8192)
 - `--sources <list>` — Comma-separated sources: `skills,decisions,histories` (default: all)
 - `--json` — Machine-readable JSON output
+- `--verbose` — Show file paths and detailed processing
+- `--notify` — Send status notification to Squad agents
 
 **When to use:**
 - Testing different context budgets before planning
@@ -112,7 +125,7 @@ Output: specs/001-feature/squad-context.md (7.7KB / 8.0KB limit)
 Override automatic review generation or create a standalone review.
 
 ```bash
-$ npx squad-speckit-bridge review specs/001-feature/tasks.md
+$ npx @jmservera/squad-speckit-bridge review specs/001-feature/tasks.md
 ```
 
 **Expected output:**
@@ -129,17 +142,18 @@ Review template written to: specs/001-feature/review.md
 **Flags:**
 - `--output <path>` — Write to custom file (default: spec directory)
 - `--json` — Machine-readable JSON output
+- `--verbose` — Show detailed analysis steps
 
 **When to use:**
 - Design Review hook is disabled and you want manual control
 - Re-generating review after tasks change
 
-### `issues` — Convert Tasks to GitHub Issues
+### `issues` — Convert Tasks to GitHub Issues (v0.2+)
 
-Convert approved tasks into GitHub issues for Squad execution. **This is the only truly manual step** (after team approves review).
+Convert approved tasks into GitHub issues for Squad execution. **This is the primary manual step** (after team approves review).
 
 ```bash
-$ npx squad-speckit-bridge issues specs/001-feature/tasks.md
+$ npx @jmservera/squad-speckit-bridge issues specs/001-feature/tasks.md
 ```
 
 **Expected output:**
@@ -147,34 +161,95 @@ $ npx squad-speckit-bridge issues specs/001-feature/tasks.md
 Creating issues from specs/001-feature/tasks.md...
 
 Created 8 issues:
-  #157: Task T1 — Set up database schema
-  #158: Task T2 — Implement user authentication
-  ... (6 more)
+  #157: T001 — Set up database schema
+  #158: T002 — Implement user authentication
+  #159: T003 — Add API endpoints
+  ... (5 more)
 
-All issues labeled with: feature/001, squad-generated
+All issues labeled with: feature/001, squad-generated, bridge
 ```
 
 **Flags:**
-- `--dry-run` — Preview without creating
-- `--labels <list>` — Additional labels: `--labels priority/high,team/backend`
-- `--json` — Machine-readable JSON output
+- `--dry-run` — Preview without creating issues:
+  ```bash
+  $ npx @jmservera/squad-speckit-bridge issues specs/001-feature/tasks.md --dry-run
+  
+  # Output shows issues that would be created:
+  # Issue 1: "T001 — Set up database schema"
+  # Issue 2: "T002 — Implement user authentication"
+  # ... (total: 8 issues)
+  ```
+
+- `--labels <list>` — Add custom labels (comma-separated):
+  ```bash
+  $ npx @jmservera/squad-speckit-bridge issues specs/001-feature/tasks.md --labels priority/high,team/backend
+  ```
+
+- `--json` — Machine-readable JSON output (returns array of created issues with numbers, URLs, labels)
+
+- `--verbose` — Show detailed processing (task parsing, dependency resolution, issue creation details)
 
 **When to use:**
-- After team approves review (always use this)
+- After team approves review (primary workflow)
+- To preview issues before committing with `--dry-run`
 - To add custom labels or assignments
-- To preview what issues will be created before committing
+- To integrate with CI/CD pipelines with `--json`
+
+### `sync` — Sync Execution Learnings (v0.2+)
+
+Capture Squad execution learnings and mark them for the next planning cycle.
+
+```bash
+$ npx @jmservera/squad-speckit-bridge sync
+```
+
+**Expected output:**
+```
+Syncing Squad learnings...
+
+Learnings since last sync (2025-07-25T10:30:00Z):
+  New decisions:  3 entries
+  New learnings:  8 entries (agent histories)
+  Affected agents: Richard, Dinesh, Monica
+
+Sync record written to: .squad/.bridge-sync-state.json
+Ready for next planning cycle.
+```
+
+**Flags:**
+- `--dry-run` — Show what would be synced without modifying:
+  ```bash
+  $ npx @jmservera/squad-speckit-bridge sync --dry-run
+  
+  # Output: What changed since last sync (counts, timestamps, summaries)
+  ```
+
+- `--since <timestamp>` — Sync changes after a specific ISO 8601 timestamp:
+  ```bash
+  $ npx @jmservera/squad-speckit-bridge sync --since 2025-07-25T10:00:00Z
+  ```
+
+- `--json` — Machine-readable output (returns sync record with change counts and summaries)
+
+- `--verbose` — Show file-by-file details of what changed in `.squad/`
+
+**When to use:**
+- After Squad completes a feature implementation (optional but recommended)
+- Before starting the next planning cycle (helps context command include latest learnings)
+- In CI/CD to ensure learnings flow back automatically with `after_implement` hook
+- Testing different sync points with `--dry-run`
 
 ### `status` — Check Bridge Health
 
 Verify installation and configuration. Useful for debugging.
 
 ```bash
-$ npx squad-speckit-bridge status
+$ npx @jmservera/squad-speckit-bridge status
 ```
 
 **Expected output:**
 ```
-Squad-SpecKit Bridge v0.1.0
+Squad-SpecKit Bridge v0.2.0
 
 Frameworks:
   Squad:    ✓ detected at .squad/
@@ -183,20 +258,33 @@ Frameworks:
 Bridge Components:
   Squad skill:      ✓ installed (.squad/skills/speckit-bridge/SKILL.md)
   Ceremony def:     ✓ installed (.squad/ceremonies/design-review.md)
-  Spec Kit ext:     ✓ installed (.specify/extensions/squad-bridge/extension.yml)
+  Spec Kit ext:     ✓ installed (.specify/extensions/squad-speckit-bridge/extension.yml)
   Manifest:         ✓ present (.bridge-manifest.json)
+
+Hooks Deployed:
+  after_tasks:      ✓ enabled
+  before_specify:   ✓ enabled (v0.2+)
+  after_implement:  ✓ enabled (v0.2+)
 
 Configuration:
   Context max size: 8192 bytes
-  After-tasks hook: enabled
   Sources:          skills, decisions, histories
+  Hooks enabled:    true
 
 Last context run:   2025-07-24T10:30:00Z
+Last sync:          2025-07-24T15:45:00Z
+Constitution:       ⚠ using template (not customized)
 ```
 
 **Flags:**
 - `--json` — Machine-readable JSON output
-- `--verbose` — Detailed diagnostics and file paths
+- `--verbose` — Detailed diagnostics including file paths, permission checks, and hook deployment details
+
+**When to use:**
+- After installation to verify all components are deployed
+- Troubleshooting automation issues
+- Checking constitution customization status (v0.2+)
+- Monitoring hook and sync state in CI/CD
 
 ---
 
@@ -219,7 +307,21 @@ After `install`, a `bridge.config.json` file is created. Customize it to change 
     "maxDecisionAgeDays": 90
   },
   "hooks": {
-    "afterTasks": true
+    "afterTasks": true,
+    "beforeSpecify": true,
+    "afterImplement": true
+  },
+  "issues": {
+    "defaultLabels": ["squad-generated", "bridge"],
+    "phaseLabels": true
+  },
+  "sync": {
+    "enabled": true,
+    "stateFile": ".squad/.bridge-sync-state.json"
+  },
+  "notifications": {
+    "enabled": false,
+    "channels": ["console"]
   },
   "paths": {
     "squadDir": ".squad",
@@ -230,15 +332,17 @@ After `install`, a `bridge.config.json` file is created. Customize it to change 
 
 ### Common Configuration Tweaks
 
-**Disable automatic hooks (fully manual mode):**
+**Disable all automation (fully manual mode):**
 ```json
 {
   "hooks": {
-    "afterTasks": false
+    "afterTasks": false,
+    "beforeSpecify": false,
+    "afterImplement": false
   }
 }
 ```
-Then run all commands explicitly (see Workflow 3 below).
+Then run all commands explicitly.
 
 **Reduce context to 4KB (minimal memory footprint):**
 ```json
@@ -248,6 +352,46 @@ Then run all commands explicitly (see Workflow 3 below).
 ```
 
 **Include only skills (no decisions or histories):**
+```json
+{
+  "sources": {
+    "skills": true,
+    "decisions": false,
+    "histories": false
+  }
+}
+```
+
+**Customize issue labels (v0.2+):**
+```json
+{
+  "issues": {
+    "defaultLabels": ["my-team", "v0.2.0"],
+    "phaseLabels": true
+  }
+}
+```
+
+**Use custom Squad directory:**
+```json
+{
+  "paths": {
+    "squadDir": "path/to/.squad"
+  }
+}
+```
+
+**Enable notifications (v0.2+):**
+```json
+{
+  "notifications": {
+    "enabled": true,
+    "channels": ["console", "squad-agents"]
+  }
+}
+```
+
+After editing `bridge.config.json`, changes take effect immediately on the next command.
 ```json
 {
   "sources": {
@@ -277,66 +421,105 @@ After editing `bridge.config.json`, changes take effect immediately on the next 
 
 ```bash
 # Step 1: Install once
-$ npx squad-speckit-bridge install
+$ npx @jmservera/squad-speckit-bridge install
 
 # Step 2: Plan normally — everything happens automatically
 $ cd specs/001-feature/
 $ /speckit.specify && /speckit.plan && /speckit.tasks
-# ← bridge creates squad-context.md and review.md automatically
+# ← bridge creates squad-context.md (v0.2+ via before_specify hook)
+# ← bridge creates review.md (via after_tasks hook)
 
 # Step 3: Team reviews (no command, just discussion)
 # Open: specs/001-feature/review.md
 # Discuss and approve
 
-# Step 4: Create issues
-$ npx squad-speckit-bridge issues specs/001-feature/tasks.md
+# Step 4: Create issues from approved tasks
+$ npx @jmservera/squad-speckit-bridge issues specs/001-feature/tasks.md
 
 # Step 5: Squad executes, agents close issues, learnings sync back
+# (Optional v0.2+: learnings automatically synced via after_implement hook)
 ```
 
 **Result:** Full knowledge loop with minimal manual overhead.
 
 ### Workflow 2: Manual Control (If Automation Disabled)
 
-If you've disabled the `afterTasks` hook:
+If you've disabled the automation hooks:
 
 ```bash
-# Disable hook in bridge.config.json first:
-# "hooks": { "afterTasks": false }
+# Disable hooks in bridge.config.json first:
+# "hooks": { "afterTasks": false, "beforeSpecify": false, "afterImplement": false }
 
 # Then run commands explicitly:
-$ npx squad-speckit-bridge context specs/001-feature/
+$ npx @jmservera/squad-speckit-bridge context specs/001-feature/
 $ cd specs/001-feature/ && /speckit.specify && /speckit.plan && /speckit.tasks
-$ npx squad-speckit-bridge review specs/001-feature/tasks.md
-$ npx squad-speckit-bridge issues specs/001-feature/tasks.md
+$ npx @jmservera/squad-speckit-bridge review specs/001-feature/tasks.md
+$ npx @jmservera/squad-speckit-bridge issues specs/001-feature/tasks.md
+
+# After Squad execution, sync learnings manually (v0.2+):
+$ npx @jmservera/squad-speckit-bridge sync
 ```
 
 **Result:** You control each step; useful for CI/CD or testing different parameters.
 
-### Workflow 3: CI/CD Integration (Quiet Mode)
-
-For automation pipelines, use `--quiet` to suppress info-level output:
+### Workflow 3: Preview Issues Before Creating (Dry Run)
 
 ```bash
-$ npx squad-speckit-bridge install --quiet
-$ npx squad-speckit-bridge context specs/001-feature/ --quiet
+# First, preview what issues will be created
+$ npx @jmservera/squad-speckit-bridge issues specs/001-feature/tasks.md --dry-run
+
+# Once satisfied, actually create them
+$ npx @jmservera/squad-speckit-bridge issues specs/001-feature/tasks.md
+
+# Or create with custom labels
+$ npx @jmservera/squad-speckit-bridge issues specs/001-feature/tasks.md --labels priority/high,team/backend
+```
+
+**Result:** Safe issue creation with preview capability.
+
+### Workflow 4: CI/CD Integration (Quiet Mode)
+
+For automation pipelines, use standard flags for controlled output:
+
+```bash
+$ npx @jmservera/squad-speckit-bridge install --quiet
+$ npx @jmservera/squad-speckit-bridge context specs/001-feature/ --json
+$ npx @jmservera/squad-speckit-bridge issues specs/001-feature/tasks.md --json
+$ npx @jmservera/squad-speckit-bridge sync --json
 ```
 
 Exit codes: `0` = success, `1` = error
 
-### Workflow 4: Testing Different Context Budgets
+**Result:** Machine-readable output for scripting and pipeline integration.
+
+### Workflow 5: Testing Different Context Budgets
 
 ```bash
 # Test with small context
-$ npx squad-speckit-bridge context specs/001-feature/ --max-size 4096
+$ npx @jmservera/squad-speckit-bridge context specs/001-feature/ --max-size 4096
 $ cd specs/001-feature/ && /speckit.plan  # See how planning differs
 
 # Test with full context
-$ npx squad-speckit-bridge context specs/001-feature/ --max-size 16384
+$ npx @jmservera/squad-speckit-bridge context specs/001-feature/ --max-size 16384
 $ cd specs/001-feature/ && /speckit.plan  # See how planning differs
 ```
 
 Useful for understanding what knowledge is most important for planning.
+
+### Workflow 6: Knowledge Debugging with Verbose Mode
+
+```bash
+# See which decisions/skills/histories were included in context
+$ npx @jmservera/squad-speckit-bridge context specs/001-feature/ --verbose
+
+# See issue creation details and dependency resolution
+$ npx @jmservera/squad-speckit-bridge issues specs/001-feature/tasks.md --verbose
+
+# See what changed in the sync
+$ npx @jmservera/squad-speckit-bridge sync --verbose
+```
+
+**Result:** Detailed tracing for understanding bridge behavior and debugging planning issues.
 
 ---
 
@@ -349,7 +532,7 @@ Useful for understanding what knowledge is most important for planning.
 | `.bridge-manifest.json` | repo root | Tracks bridge version and installed components |
 | `.squad/skills/speckit-bridge/SKILL.md` | .squad/ | Teaches agents about Spec Kit artifacts and Design Review |
 | `.squad/ceremonies/design-review.md` | .squad/ | Ceremony definition for Design Review |
-| `.specify/extensions/squad-bridge/extension.yml` | .specify/ | Hook definitions for automation |
+| `.specify/extensions/squad-speckit-bridge/extension.yml` | .specify/ | Hook definitions for automation (after_tasks, before_specify, after_implement) |
 | `bridge.config.json` | repo root | Configuration (customizable) |
 
 **Why commit them?** They're part of your integration setup. Team members and future deployments need to know what's configured.
@@ -358,8 +541,9 @@ Useful for understanding what knowledge is most important for planning.
 
 | File | Location | Created By | Purpose |
 |------|----------|------------|---------|
-| `squad-context.md` | specs/{feature}/ | Automatic (or `context` command) | Squad memory summary fed into planning |
-| `review.md` | specs/{feature}/ | Automatic (after `/speckit.tasks`) | Design Review template with findings |
+| `squad-context.md` | specs/{feature}/ | Automatic (v0.2+ via `before_specify` hook) or `context` command | Squad memory summary fed into planning |
+| `review.md` | specs/{feature}/ | Automatic (via `after_tasks` hook) or `review` command | Design Review template with findings |
+| `.squad/.bridge-sync-state.json` | .squad/ | Automatic (v0.2+ via `after_implement` hook) or `sync` command | Tracks last sync point for learnings capture |
 
 **Why commit them?** They're part of your feature's planning record. Future planning cycles and team members benefit from seeing what knowledge informed decisions and what the review found.
 
@@ -385,13 +569,20 @@ Useful for understanding what knowledge is most important for planning.
 **`context`:**
 - `--max-size <bytes>` — Context budget (default: 8192)
 - `--sources <list>` — Comma-separated sources (default: skills,decisions,histories)
+- `--notify` — Send status notification to Squad (v0.2+)
 
 **`review`:**
 - `--output <path>` — Custom output file (default: spec directory)
 
-**`issues`:**
+**`issues` (v0.2+):**
 - `--dry-run` — Preview without creating
 - `--labels <list>` — Comma-separated labels to apply
+- `--json` — JSON output with created issue details
+
+**`sync` (v0.2+):**
+- `--dry-run` — Preview without syncing
+- `--since <timestamp>` — Sync changes after timestamp
+- `--json` — JSON output with sync record
 
 ---
 
@@ -403,3 +594,5 @@ Useful for understanding what knowledge is most important for planning.
 | `SPECKIT_NOT_FOUND` | `.specify/` missing | Run `npx speckit init` |
 | `PERMISSION_DENIED` | Can't read/write files | Check permissions: `chmod -R u+w .squad/ .specify/` |
 | `HOOK_DISABLED` | `afterTasks` is false in config | Enable in `bridge.config.json` or use manual commands |
+| `GITHUB_AUTH_FAILED` (v0.2+) | Missing GitHub token for issues | Set GITHUB_TOKEN environment variable |
+| `INVALID_TASKS_FILE` (v0.2+) | tasks.md format unrecognized | Ensure file is generated by Spec Kit |


### PR DESCRIPTION
Implement Monica's v0.2.0 documentation tasks.

## Changes

### T044: README.md Updates
- Document new v0.2.0 commands (`issues`, `sync`)
- Document new automation hooks (`before_specify`, `after_implement`)
- Update Quick Start with scoped package name
- Update Project Status to reflect v0.2.0

### T045: docs/usage.md Updates
- Document `issues` command with examples (`--dry-run`, `--labels`, `--json`)
- Document `sync` command with examples (`--dry-run`, `--since`)
- Update all examples to use `@jmservera/squad-speckit-bridge` scoped name
- Add 6 common workflows with copy-pasteable commands
- Document v0.2.0 config options
- Add `--verbose` and `--notify` flag documentation

### T047: CHANGELOG.md Creation
- Document v0.2.0 changes grouped by:
  - Bug Fixes (hook deployment, extension alignment, CLI contracts)
  - New Features (issues, sync, hooks)
  - Improvements (verbose logging, constitution detection)
- Include v0.1.0 section with full release history
- Add versioning and changelog reading guide

Closes #104 #105 #106