### PR TITLE
feat(sync): extend syncLearnings with idempotent extraction [T008]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,20 @@
 {
-  "name": "squad-speckit-bridge",
-  "version": "0.1.0",
+  "name": "@jmservera/squad-speckit-bridge",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "squad-speckit-bridge",
-      "version": "0.1.0",
-      "license": "ISC",
+      "name": "@jmservera/squad-speckit-bridge",
+      "version": "0.2.0",
+      "license": "MIT",
       "dependencies": {
         "commander": "^14.0.3",
         "glob": "^13.0.6",
         "gray-matter": "^4.0.3"
       },
       "bin": {
+        "sqsk": "dist/cli/index.js",
         "squad-speckit-bridge": "dist/cli/index.js"
       },
       "devDependencies": {
@@ -21,6 +22,9 @@
         "tsx": "^4.21.0",
         "typescript": "^5.9.3",
         "vitest": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@emnapi/core": {
@@ -844,7 +848,6 @@
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -1611,7 +1614,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1809,7 +1811,6 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -1851,7 +1852,6 @@
       "integrity": "sha512-wt+Z2qIhfFt85uiyRt5LPU4oVEJBXj8hZNWKeqFG4gRG/0RaRGJ7njQCwzFVjO+v4+Ipmf5CY7VdmZRAYYBPHw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.3",

--- a/src/sync/adapters/agent-history-reader.ts
+++ b/src/sync/adapters/agent-history-reader.ts
@@ -1,0 +1,82 @@
+/**
+ * AgentHistoryReaderAdapter
+ *
+ * Implements AgentHistoryReader port.
+ * Reads agent history/output files from .squad/agents/{name}/history.md
+ * and extracts timestamped learning entries.
+ *
+ * Adapter layer — uses fs/promises and glob (framework), implements port.
+ */
+
+import { readFile } from 'node:fs/promises';
+import { join, basename, dirname } from 'node:path';
+import { glob } from 'glob';
+import type { AgentHistoryReader, ExtractedLearning } from '../sync-learnings.js';
+
+export class AgentHistoryReaderAdapter implements AgentHistoryReader {
+
+  async extractLearnings(agentDir: string, since?: Date): Promise<ExtractedLearning[]> {
+    const pattern = join(agentDir, '**', 'history.md').replace(/\\/g, '/');
+    let files: string[];
+
+    try {
+      files = await glob(pattern);
+    } catch {
+      return [];
+    }
+
+    const learnings: ExtractedLearning[] = [];
+
+    for (const file of files) {
+      try {
+        const content = await readFile(file, 'utf-8');
+        const agentName = basename(dirname(file));
+        const entries = this.parseHistoryEntries(content, agentName, file);
+
+        for (const entry of entries) {
+          if (since) {
+            const entryDate = new Date(entry.timestamp);
+            if (isNaN(entryDate.getTime()) || entryDate < since) continue;
+          }
+          learnings.push(entry);
+        }
+      } catch {
+        // Skip unreadable files
+      }
+    }
+
+    return learnings;
+  }
+
+  private parseHistoryEntries(
+    content: string,
+    agentName: string,
+    source: string,
+  ): ExtractedLearning[] {
+    const entries: ExtractedLearning[] = [];
+    const sections = content.split(/^###\s+/m).filter(s => s.trim());
+
+    for (const section of sections) {
+      const lines = section.split('\n');
+      const heading = lines[0].trim();
+      const dateMatch = heading.match(/^(\d{4}-\d{2}-\d{2}):\s*(.+)/);
+      if (!dateMatch) continue;
+
+      const timestamp = dateMatch[1];
+      const title = dateMatch[2].trim();
+      const body = lines.slice(1).join('\n').trim();
+
+      if (title) {
+        entries.push({
+          agentName,
+          timestamp,
+          title,
+          content: body || title,
+          source,
+        });
+      }
+    }
+
+    return entries;
+  }
+}

--- a/src/sync/sync-learnings.ts
+++ b/src/sync/sync-learnings.ts
@@ -1,8 +1,9 @@
 /**
- * T027: SyncLearnings Use Case
+ * T027 + T008: SyncLearnings Use Case
  *
- * Reads execution results from a spec directory and updates Squad
- * memory with implementation learnings. Tracks sync state.
+ * Reads execution results from a spec directory and agent history files,
+ * then updates Squad memory with implementation learnings. Tracks sync state
+ * with timestamp-based idempotent extraction and fingerprint deduplication.
  *
  * Clean Architecture: imports ONLY from ../types.ts and ../bridge/ports.ts.
  */
@@ -10,10 +11,15 @@
 import type { SyncRecord, SyncState } from '../types.js';
 import type { SquadMemoryWriter } from '../bridge/ports.js';
 
+/* ------------------------------------------------------------------ */
+/*  Types                                                              */
+/* ------------------------------------------------------------------ */
+
 export interface SyncOptions {
   specDir: string;
   squadDir: string;
   dryRun: boolean;
+  agentDir?: string;
 }
 
 export interface SyncResult {
@@ -21,26 +27,93 @@ export interface SyncResult {
   dryRun: boolean;
 }
 
+export interface ExtractedLearning {
+  agentName: string;
+  timestamp: string;
+  title: string;
+  content: string;
+  source: string;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Port interfaces                                                    */
+/* ------------------------------------------------------------------ */
+
 export interface SyncStateReader {
   readSyncState(squadDir: string): Promise<SyncState | null>;
   writeSyncState(squadDir: string, state: SyncState): Promise<void>;
   readSpecResults(specDir: string): Promise<{ title: string; content: string }[]>;
 }
 
+/** Reads agent history/output files and extracts learnings. */
+export interface AgentHistoryReader {
+  extractLearnings(agentDir: string, since?: Date): Promise<ExtractedLearning[]>;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Pure helpers                                                       */
+/* ------------------------------------------------------------------ */
+
+/** Extended sync state that tracks fingerprints for deduplication. */
+interface SyncStateWithFingerprints extends SyncState {
+  syncedFingerprints?: string[];
+}
+
+/**
+ * Compute a deterministic fingerprint for a learning entry.
+ * Used to prevent duplicate syncs across runs (idempotency).
+ * DJB2 hash over normalized title + content.
+ */
+export function computeLearningFingerprint(title: string, content: string): string {
+  const normalized = `${title.trim().toLowerCase()}::${content.trim().toLowerCase()}`;
+  let hash = 5381;
+  for (let i = 0; i < normalized.length; i++) {
+    hash = ((hash << 5) + hash + normalized.charCodeAt(i)) & 0xffffffff;
+  }
+  return `fp_${(hash >>> 0).toString(36)}`;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Use case                                                           */
+/* ------------------------------------------------------------------ */
+
 export async function syncLearnings(
   stateAdapter: SyncStateReader,
   memoryWriter: SquadMemoryWriter,
   options: SyncOptions,
+  historyReader?: AgentHistoryReader,
 ): Promise<SyncResult> {
-  const { specDir, squadDir, dryRun } = options;
+  const { specDir, squadDir, dryRun, agentDir } = options;
 
-  // Read previous sync state
-  const prevState = await stateAdapter.readSyncState(squadDir);
+  // Read previous sync state (may contain fingerprints from prior runs)
+  const prevState = (await stateAdapter.readSyncState(squadDir)) as SyncStateWithFingerprints | null;
+  const existingFingerprints = new Set(prevState?.syncedFingerprints ?? []);
 
-  // Read execution results from spec dir
-  const results = await stateAdapter.readSpecResults(specDir);
+  // Timestamp gate: only extract learnings newer than last sync
+  const sinceDate = prevState?.lastSyncTimestamp
+    ? new Date(prevState.lastSyncTimestamp)
+    : undefined;
 
-  if (results.length === 0) {
+  // Collect learnings from all sources
+  const allLearnings: { title: string; content: string }[] = [];
+
+  // Source 1: execution results from spec directory
+  const specResults = await stateAdapter.readSpecResults(specDir);
+  allLearnings.push(...specResults);
+
+  // Source 2: agent history files (timestamp-filtered at the reader)
+  if (historyReader && agentDir) {
+    const extracted = await historyReader.extractLearnings(agentDir, sinceDate);
+    for (const learning of extracted) {
+      allLearnings.push({
+        title: learning.title,
+        content: `[${learning.agentName}] ${learning.content}`,
+      });
+    }
+  }
+
+  // No results from any source
+  if (allLearnings.length === 0) {
     const record: SyncRecord = {
       syncTimestamp: new Date().toISOString(),
       learningsUpdated: 0,
@@ -50,32 +123,51 @@ export async function syncLearnings(
     return { record, dryRun };
   }
 
+  // Deduplicate: skip learnings whose fingerprint was already synced
+  const newLearnings = allLearnings.filter((l) => {
+    const fp = computeLearningFingerprint(l.title, l.content);
+    return !existingFingerprints.has(fp);
+  });
+
+  if (newLearnings.length === 0) {
+    const record: SyncRecord = {
+      syncTimestamp: new Date().toISOString(),
+      learningsUpdated: 0,
+      filesWritten: [],
+      summary: 'All learnings already synced — nothing new to write.',
+    };
+    return { record, dryRun };
+  }
+
   const filesWritten: string[] = [];
+  const newFingerprints: string[] = [];
 
   if (!dryRun) {
-    // Write each result as a learning entry
-    for (const result of results) {
+    for (const learning of newLearnings) {
       const path = await memoryWriter.writeLearning(
         'bridge',
-        result.title,
-        result.content,
+        learning.title,
+        learning.content,
       );
       filesWritten.push(path);
+      newFingerprints.push(computeLearningFingerprint(learning.title, learning.content));
     }
 
-    // Update sync state
-    const newState: SyncState = {
+    // Persist fingerprints so the next run skips these learnings
+    const updatedFingerprints = [...existingFingerprints, ...newFingerprints];
+    const newState: SyncStateWithFingerprints = {
       lastSyncTimestamp: new Date().toISOString(),
       syncHistory: [
         ...(prevState?.syncHistory ?? []),
         {
           syncTimestamp: new Date().toISOString(),
-          learningsUpdated: results.length,
+          learningsUpdated: newLearnings.length,
           filesWritten,
-          summary: `Synced ${results.length} learning(s) from ${specDir}`,
+          summary: `Synced ${newLearnings.length} learning(s) from ${specDir}`,
         },
       ],
       totalSyncs: (prevState?.totalSyncs ?? 0) + 1,
+      syncedFingerprints: updatedFingerprints,
     };
 
     await stateAdapter.writeSyncState(squadDir, newState);
@@ -83,11 +175,11 @@ export async function syncLearnings(
 
   const record: SyncRecord = {
     syncTimestamp: new Date().toISOString(),
-    learningsUpdated: results.length,
+    learningsUpdated: newLearnings.length,
     filesWritten,
     summary: dryRun
-      ? `[DRY RUN] Would sync ${results.length} learning(s) from ${specDir}`
-      : `Synced ${results.length} learning(s) from ${specDir}`,
+      ? `[DRY RUN] Would sync ${newLearnings.length} learning(s) from ${specDir}`
+      : `Synced ${newLearnings.length} learning(s) from ${specDir}`,
   };
 
   return { record, dryRun };

--- a/tests/unit/sync-learnings.test.ts
+++ b/tests/unit/sync-learnings.test.ts
@@ -1,7 +1,19 @@
 import { describe, it, expect, vi } from 'vitest';
-import { syncLearnings } from '../../src/sync/sync-learnings.js';
-import type { SyncStateReader } from '../../src/sync/sync-learnings.js';
+import {
+  syncLearnings,
+  computeLearningFingerprint,
+} from '../../src/sync/sync-learnings.js';
+import type {
+  SyncStateReader,
+  AgentHistoryReader,
+  ExtractedLearning,
+} from '../../src/sync/sync-learnings.js';
 import type { SquadMemoryWriter } from '../../src/bridge/ports.js';
+import type { SyncState } from '../../src/types.js';
+
+/* ------------------------------------------------------------------ */
+/*  Factory helpers                                                    */
+/* ------------------------------------------------------------------ */
 
 function makeStateReader(overrides: Partial<SyncStateReader> = {}): SyncStateReader {
   return {
@@ -22,6 +34,20 @@ function makeMemoryWriter(overrides: Partial<SquadMemoryWriter> = {}): SquadMemo
     ...overrides,
   };
 }
+
+function makeHistoryReader(
+  learnings: ExtractedLearning[] = [],
+): AgentHistoryReader {
+  return {
+    extractLearnings: vi.fn().mockResolvedValue(learnings),
+  };
+}
+
+const defaultOpts = { specDir: 'specs/001', squadDir: '.squad', dryRun: false };
+
+/* ------------------------------------------------------------------ */
+/*  Original behaviour (backward-compatible)                           */
+/* ------------------------------------------------------------------ */
 
 describe('syncLearnings', () => {
   it('syncs completed task results to squad memory', async () => {
@@ -113,3 +139,387 @@ describe('syncLearnings', () => {
     expect(state.syncHistory).toHaveLength(2);
   });
 });
+
+/* ------------------------------------------------------------------ */
+/*  computeLearningFingerprint                                         */
+/* ------------------------------------------------------------------ */
+
+describe('computeLearningFingerprint', () => {
+  it('produces consistent fingerprints for identical content', () => {
+    const fp1 = computeLearningFingerprint('Title A', 'Content body');
+    const fp2 = computeLearningFingerprint('Title A', 'Content body');
+    expect(fp1).toBe(fp2);
+  });
+
+  it('produces different fingerprints for different titles', () => {
+    const fp1 = computeLearningFingerprint('Title A', 'Same body');
+    const fp2 = computeLearningFingerprint('Title B', 'Same body');
+    expect(fp1).not.toBe(fp2);
+  });
+
+  it('produces different fingerprints for different content', () => {
+    const fp1 = computeLearningFingerprint('Same title', 'Body one');
+    const fp2 = computeLearningFingerprint('Same title', 'Body two');
+    expect(fp1).not.toBe(fp2);
+  });
+
+  it('is case-insensitive', () => {
+    const fp1 = computeLearningFingerprint('TITLE', 'CONTENT');
+    const fp2 = computeLearningFingerprint('title', 'content');
+    expect(fp1).toBe(fp2);
+  });
+
+  it('ignores leading/trailing whitespace', () => {
+    const fp1 = computeLearningFingerprint('  Title  ', '  Content  ');
+    const fp2 = computeLearningFingerprint('Title', 'Content');
+    expect(fp1).toBe(fp2);
+  });
+
+  it('returns a string starting with fp_', () => {
+    const fp = computeLearningFingerprint('t', 'c');
+    expect(fp).toMatch(/^fp_[a-z0-9]+$/);
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  Idempotent deduplication                                           */
+/* ------------------------------------------------------------------ */
+
+describe('syncLearnings — idempotent deduplication', () => {
+  it('skips learnings whose fingerprint already exists in sync state', async () => {
+    const fp1 = computeLearningFingerprint('Task T001 completed', 'Setup complete');
+    const fp2 = computeLearningFingerprint('Task T002 completed', 'Build passes');
+
+    const prevState = {
+      lastSyncTimestamp: '2025-07-01T00:00:00.000Z',
+      syncHistory: [],
+      totalSyncs: 1,
+      syncedFingerprints: [fp1, fp2],
+    };
+
+    const stateReader = makeStateReader({
+      readSyncState: vi.fn().mockResolvedValue(prevState),
+    });
+    const writer = makeMemoryWriter();
+
+    const result = await syncLearnings(stateReader, writer, defaultOpts);
+
+    expect(result.record.learningsUpdated).toBe(0);
+    expect(result.record.summary).toContain('already synced');
+    expect(writer.writeLearning).not.toHaveBeenCalled();
+  });
+
+  it('only syncs learnings not yet fingerprinted', async () => {
+    const fp1 = computeLearningFingerprint('Task T001 completed', 'Setup complete');
+
+    const prevState = {
+      lastSyncTimestamp: '2025-07-01T00:00:00.000Z',
+      syncHistory: [],
+      totalSyncs: 1,
+      syncedFingerprints: [fp1],
+    };
+
+    const stateReader = makeStateReader({
+      readSyncState: vi.fn().mockResolvedValue(prevState),
+    });
+    const writer = makeMemoryWriter();
+
+    const result = await syncLearnings(stateReader, writer, defaultOpts);
+
+    expect(result.record.learningsUpdated).toBe(1);
+    expect(writer.writeLearning).toHaveBeenCalledTimes(1);
+    expect(writer.writeLearning).toHaveBeenCalledWith(
+      'bridge',
+      'Task T002 completed',
+      'Build passes',
+    );
+  });
+
+  it('persists new fingerprints in sync state for future runs', async () => {
+    const writeSyncState = vi.fn().mockResolvedValue(undefined);
+    const stateReader = makeStateReader({ writeSyncState });
+    const writer = makeMemoryWriter();
+
+    await syncLearnings(stateReader, writer, defaultOpts);
+
+    const state = writeSyncState.mock.calls[0][1];
+    expect(state.syncedFingerprints).toBeDefined();
+    expect(state.syncedFingerprints).toHaveLength(2);
+    expect(state.syncedFingerprints[0]).toMatch(/^fp_/);
+  });
+
+  it('accumulates fingerprints across multiple syncs', async () => {
+    const existingFp = computeLearningFingerprint('Old learning', 'Old content');
+    const prevState = {
+      lastSyncTimestamp: '2025-07-01T00:00:00.000Z',
+      syncHistory: [],
+      totalSyncs: 1,
+      syncedFingerprints: [existingFp],
+    };
+    const writeSyncState = vi.fn().mockResolvedValue(undefined);
+    const stateReader = makeStateReader({
+      readSyncState: vi.fn().mockResolvedValue(prevState),
+      writeSyncState,
+    });
+    const writer = makeMemoryWriter();
+
+    await syncLearnings(stateReader, writer, defaultOpts);
+
+    const state = writeSyncState.mock.calls[0][1];
+    // Old fingerprint + 2 new ones
+    expect(state.syncedFingerprints).toHaveLength(3);
+    expect(state.syncedFingerprints).toContain(existingFp);
+  });
+
+  it('running sync twice with identical input is idempotent', async () => {
+    // First run: no previous state
+    const writeSyncState = vi.fn().mockResolvedValue(undefined);
+    const stateReader1 = makeStateReader({ writeSyncState });
+    const writer1 = makeMemoryWriter();
+
+    await syncLearnings(stateReader1, writer1, defaultOpts);
+    const stateAfterFirst = writeSyncState.mock.calls[0][1];
+
+    // Second run: use state from first run
+    const writeSyncState2 = vi.fn().mockResolvedValue(undefined);
+    const stateReader2 = makeStateReader({
+      readSyncState: vi.fn().mockResolvedValue(stateAfterFirst),
+      writeSyncState: writeSyncState2,
+    });
+    const writer2 = makeMemoryWriter();
+
+    const result = await syncLearnings(stateReader2, writer2, defaultOpts);
+
+    expect(result.record.learningsUpdated).toBe(0);
+    expect(result.record.summary).toContain('already synced');
+    expect(writer2.writeLearning).not.toHaveBeenCalled();
+    expect(writeSyncState2).not.toHaveBeenCalled();
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  Agent history reader integration                                   */
+/* ------------------------------------------------------------------ */
+
+describe('syncLearnings — agent history extraction', () => {
+  const agentLearnings: ExtractedLearning[] = [
+    {
+      agentName: 'gilfoyle',
+      timestamp: '2025-07-15',
+      title: 'Discovered caching pattern',
+      content: 'LRU cache reduces API calls by 60%',
+      source: '.squad/agents/gilfoyle/history.md',
+    },
+    {
+      agentName: 'dinesh',
+      timestamp: '2025-07-16',
+      title: 'Test parallelism insight',
+      content: 'Vitest runs 3x faster with pool threads',
+      source: '.squad/agents/dinesh/history.md',
+    },
+  ];
+
+  it('extracts and syncs learnings from agent history', async () => {
+    const stateReader = makeStateReader({
+      readSpecResults: vi.fn().mockResolvedValue([]),
+    });
+    const writer = makeMemoryWriter();
+    const reader = makeHistoryReader(agentLearnings);
+
+    const result = await syncLearnings(
+      stateReader,
+      writer,
+      { ...defaultOpts, agentDir: '.squad/agents' },
+      reader,
+    );
+
+    expect(result.record.learningsUpdated).toBe(2);
+    expect(writer.writeLearning).toHaveBeenCalledTimes(2);
+    expect(writer.writeLearning).toHaveBeenCalledWith(
+      'bridge',
+      'Discovered caching pattern',
+      '[gilfoyle] LRU cache reduces API calls by 60%',
+    );
+  });
+
+  it('passes sinceDate from last sync to history reader', async () => {
+    const prevState: SyncState = {
+      lastSyncTimestamp: '2025-07-10T00:00:00.000Z',
+      syncHistory: [],
+      totalSyncs: 1,
+    };
+    const stateReader = makeStateReader({
+      readSyncState: vi.fn().mockResolvedValue(prevState),
+      readSpecResults: vi.fn().mockResolvedValue([]),
+    });
+    const writer = makeMemoryWriter();
+    const reader = makeHistoryReader([]);
+
+    await syncLearnings(
+      stateReader,
+      writer,
+      { ...defaultOpts, agentDir: '.squad/agents' },
+      reader,
+    );
+
+    expect(reader.extractLearnings).toHaveBeenCalledWith(
+      '.squad/agents',
+      new Date('2025-07-10T00:00:00.000Z'),
+    );
+  });
+
+  it('passes undefined sinceDate when no previous sync', async () => {
+    const stateReader = makeStateReader({
+      readSpecResults: vi.fn().mockResolvedValue([]),
+    });
+    const writer = makeMemoryWriter();
+    const reader = makeHistoryReader([]);
+
+    await syncLearnings(
+      stateReader,
+      writer,
+      { ...defaultOpts, agentDir: '.squad/agents' },
+      reader,
+    );
+
+    expect(reader.extractLearnings).toHaveBeenCalledWith(
+      '.squad/agents',
+      undefined,
+    );
+  });
+
+  it('does not call history reader when agentDir is not provided', async () => {
+    const stateReader = makeStateReader();
+    const writer = makeMemoryWriter();
+    const reader = makeHistoryReader(agentLearnings);
+
+    await syncLearnings(stateReader, writer, defaultOpts, reader);
+
+    expect(reader.extractLearnings).not.toHaveBeenCalled();
+  });
+
+  it('does not call history reader when reader is not provided', async () => {
+    const stateReader = makeStateReader();
+    const writer = makeMemoryWriter();
+
+    const result = await syncLearnings(stateReader, writer, {
+      ...defaultOpts,
+      agentDir: '.squad/agents',
+    });
+
+    // Should still sync spec results
+    expect(result.record.learningsUpdated).toBe(2);
+  });
+
+  it('combines spec results and agent history learnings', async () => {
+    const stateReader = makeStateReader(); // 2 spec results
+    const writer = makeMemoryWriter();
+    const reader = makeHistoryReader(agentLearnings); // 2 agent learnings
+
+    const result = await syncLearnings(
+      stateReader,
+      writer,
+      { ...defaultOpts, agentDir: '.squad/agents' },
+      reader,
+    );
+
+    expect(result.record.learningsUpdated).toBe(4);
+    expect(writer.writeLearning).toHaveBeenCalledTimes(4);
+  });
+
+  it('deduplicates across spec results and agent history', async () => {
+    // Agent learning has same content as a spec result
+    const dupLearning: ExtractedLearning = {
+      agentName: 'bridge',
+      timestamp: '2025-07-15',
+      title: 'Task T001 completed',
+      content: 'Setup complete',
+      source: 'history.md',
+    };
+    // Pre-fingerprint one spec result
+    const fp = computeLearningFingerprint('Task T001 completed', 'Setup complete');
+    const prevState = {
+      lastSyncTimestamp: '2025-07-01T00:00:00.000Z',
+      syncHistory: [],
+      totalSyncs: 1,
+      syncedFingerprints: [fp],
+    };
+    const stateReader = makeStateReader({
+      readSyncState: vi.fn().mockResolvedValue(prevState),
+    });
+    const writer = makeMemoryWriter();
+    // The agent learning content gets prefixed with [bridge], making it unique
+    const reader = makeHistoryReader([dupLearning]);
+
+    const result = await syncLearnings(
+      stateReader,
+      writer,
+      { ...defaultOpts, agentDir: '.squad/agents' },
+      reader,
+    );
+
+    // T001 spec result is deduped, T002 spec result + agent learning (prefixed) = 2
+    expect(result.record.learningsUpdated).toBe(2);
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  Context generation verification                                    */
+/* ------------------------------------------------------------------ */
+
+describe('syncLearnings — context generation feedback loop', () => {
+  it('writes learnings in format compatible with history.md parsing', async () => {
+    const writeLearning = vi.fn().mockResolvedValue('.squad/agents/bridge/history.md');
+    const stateReader = makeStateReader({
+      readSpecResults: vi.fn().mockResolvedValue([
+        { title: 'Caching strategy', content: 'Use Redis for session store' },
+      ]),
+    });
+    const writer = makeMemoryWriter({ writeLearning });
+
+    await syncLearnings(stateReader, writer, defaultOpts);
+
+    expect(writeLearning).toHaveBeenCalledWith(
+      'bridge',
+      'Caching strategy',
+      'Use Redis for session store',
+    );
+    // The SquadMemoryWriter.writeLearning contract produces entries in
+    // ### YYYY-MM-DD: Title\n\nContent format, which parseHistoryFile reads.
+    // buildSquadContext → reader.readLearnings() picks these up.
+  });
+
+  it('writes to squad agents directory so context builder discovers them', async () => {
+    const paths: string[] = [];
+    const writeLearning = vi.fn().mockImplementation(async () => {
+      const p = '.squad/agents/bridge/history.md';
+      paths.push(p);
+      return p;
+    });
+    const stateReader = makeStateReader();
+    const writer = makeMemoryWriter({ writeLearning });
+
+    const result = await syncLearnings(stateReader, writer, defaultOpts);
+
+    // All written files are in .squad/agents/ which SquadFileReader globs
+    for (const f of result.record.filesWritten) {
+      expect(f).toContain('.squad/agents/');
+      expect(f).toContain('history.md');
+    }
+  });
+
+  it('dry run reports learnings that would appear in next context', async () => {
+    const stateReader = makeStateReader();
+    const writer = makeMemoryWriter();
+
+    const result = await syncLearnings(stateReader, writer, {
+      ...defaultOpts,
+      dryRun: true,
+    });
+
+    expect(result.record.learningsUpdated).toBe(2);
+    expect(result.record.summary).toContain('DRY RUN');
+    expect(result.record.summary).toContain('2 learning(s)');
+  });
+});
+


### PR DESCRIPTION
## Summary
Extends `syncLearnings` with:
- **AgentHistoryReader** port + adapter for extracting learnings from agent history files
- **Fingerprint dedup** (DJB2 hash) — running twice produces same result
- **Timestamp-based filtering** — only extracts learnings since last sync
- Backward compatible with existing 3-arg calls

21 new tests, **204 total passing**.

Closes #263

---
*Agent: 🔬 Gilfoyle (T008) • Batch 5*