### PR TITLE
docs(agents): add bridge command prompts to SpecKit agents [T010]

### DIFF
--- a/.github/agents/speckit.analyze.agent.md
+++ b/.github/agents/speckit.analyze.agent.md
@@ -158,6 +158,26 @@ At end of report, output a concise Next Actions block:
 - If only LOW/MEDIUM: User may proceed, but provide improvement suggestions
 - Provide explicit command suggestions: e.g., "Run /speckit.specify with refinement", "Run /speckit.plan to adjust architecture", "Manually edit tasks.md to add coverage for 'performance-metrics'"
 
+## Bridge Integration: Quality Assurance & Squad Readiness
+
+Before handing off tasks to Squad execution via `sqsk issues`, ensure quality:
+
+**Quality gate checklist** (to decide if ready for `sqsk issues`):
+- ✅ No CRITICAL severity findings in analysis report
+- ✅ All requirements mapped to tasks (coverage ≥90%)
+- ✅ No constitution violations
+- ✅ All tasks follow checklist format
+- ✅ Dependency graph is acyclic (no circular dependencies)
+
+**If findings exist**:
+- **CRITICAL issues**: Do NOT run `sqsk issues` yet. Fix the issues first (re-run `/speckit.specify`, `/speckit.plan`, or `/speckit.tasks`)
+- **HIGH issues**: Consider fixing before `sqsk issues`, or proceed with documented risk
+- **MEDIUM/LOW issues**: Safe to proceed; add findings to design review if available
+
+**After fixing issues**: Re-run this analysis to confirm quality improvement.
+
+---
+
 ### 8. Offer Remediation
 
 Ask the user: "Would you like me to suggest concrete remediation edits for the top N issues?" (Do NOT apply them automatically.)

--- a/.github/agents/speckit.checklist.agent.md
+++ b/.github/agents/speckit.checklist.agent.md
@@ -293,3 +293,21 @@ Sample items:
 - Correct: Validation of requirement quality
 - Wrong: "Does it do X?"
 - Correct: "Is X clearly specified?"
+
+## Bridge Integration: Design Review & Squad Communication
+
+Before implementing, a comprehensive checklist ensures team alignment:
+
+**Design Review Process** (optional but recommended):
+1. Complete this checklist as a quality gate
+2. Review the checklist with cross-functional team (design, backend, frontend, product)
+3. Mark any gaps or concerns for discussion
+4. If major gaps found, cycle back to `/speckit.specify` or `/speckit.plan` before proceeding
+
+**Using this in Squad workflow**:
+- **Squad-aware teams** running the bridge can run `/speckit.checklist` to ensure Design Review readiness
+- **Create issues from checklist**: If your team uses Design Review ceremony, ensure checklist gaps are addressed before marking tasks.md as ready for `sqsk issues`
+- **Feedback loop**: If checklist reveals gaps, update spec/plan → regenerate tasks → re-run checklist until passing
+
+**Optional bridge integration**: The bridge can be configured to auto-generate a Design Review artifact (review.md) after this checklist completes, documenting team decisions and any waivers on open items.
+

--- a/.github/agents/speckit.clarify.agent.md
+++ b/.github/agents/speckit.clarify.agent.md
@@ -178,4 +178,22 @@ Behavior rules:
 - If no questions asked due to full coverage, output a compact coverage summary (all categories Clear) then suggest advancing.
 - If quota reached with unresolved high-impact categories remaining, explicitly flag them under Deferred with rationale.
 
+## Bridge Integration: Specification Clarity & Planning Readiness
+
+After clarifications are complete, the spec is ready for the planning stage:
+
+**Next steps**:
+1. **Run `/speckit.plan`** — Plan generates technical architecture, data model, and design contracts
+2. **Squad context injection** — If bridge is enabled, the planning phase will automatically inject squad-context.md with prior team learnings
+3. **Iterative refinement** — If planning uncovers gaps, you can cycle back to `/speckit.clarify` (max 1 cycle recommended)
+
+**Why clarify before planning?**
+- Reduces rework during planning (plans build on clear specs)
+- Ensures specification ambiguities don't cascade into architectural confusion
+- Captures team decisions early (valuable for future reference and learning)
+
+**Bridge flow**: Clarified Spec → Plan (informed by squad-context) → Tasks → `sqsk issues` → Squad execution → Learnings captured
+
+---
+
 Context for prioritization: $ARGUMENTS

--- a/.github/agents/speckit.constitution.agent.md
+++ b/.github/agents/speckit.constitution.agent.md
@@ -82,3 +82,20 @@ If the user supplies partial updates (e.g., only one principle revision), still 
 If critical info missing (e.g., ratification date truly unknown), insert `TODO(<FIELD_NAME>): explanation` and include in the Sync Impact Report under deferred items.
 
 Do not create a new template; always operate on the existing `.specify/memory/constitution.md` file.
+
+## Bridge Integration: Governance & Squad Alignment
+
+The updated constitution feeds into all SpecKit and Squad agents:
+
+**How constitution shapes planning**:
+- During `/speckit.plan`, the bridge automatically validates planning against constitution principles
+- During `/speckit.analyze`, violations are flagged as CRITICAL findings
+- During team execution, Squad agents have access to constitution via `squad-context.md`
+
+**After updating constitution**:
+1. **Re-run dependent workflows** — If major changes made, re-run `/speckit.plan` and `/speckit.analyze` to ensure all existing artifacts remain compliant
+2. **Update squad knowledge** — If bridge is enabled, Squad agents automatically get the updated constitution in next context injection
+3. **Future features** — New features will build on the updated governance from the start
+
+**Why this matters for the pipeline**: Constitution ensures that SpecKit planning and Squad execution stay aligned to project values and quality standards. Changes propagate automatically through the bridge.
+

--- a/.github/agents/speckit.implement.agent.md
+++ b/.github/agents/speckit.implement.agent.md
@@ -168,6 +168,27 @@ You **MUST** consider the user input before proceeding (if not empty).
 
 Note: This command assumes a complete task breakdown exists in tasks.md. If tasks are incomplete or missing, suggest running `/speckit.tasks` first to regenerate the task list.
 
+## Bridge Integration: Learning Capture & Feedback Loop
+
+During and after implementation, the bridge captures execution learnings:
+
+**How the bridge improves next planning cycle**:
+- **`sqsk sync`** — After completing major milestones or the full implementation, sync execution learnings back to Squad memory
+- **Automatic capture** — If bridge hooks are enabled, learnings are automatically captured after implementation completes
+- **What gets captured**: Decisions made during implementation, architectural changes, performance learnings, bugs encountered and fixed
+- **Why it matters**: The next feature planning cycle automatically has access to what you learned. Plans get progressively better.
+
+**The feedback loop**:
+1. Spec → Plan → Tasks → `sqsk issues` (GitHub issues created)
+2. Implementation (tasks.md executed)
+3. `sqsk sync` (learnings captured) or automatic hook after `after_implement`
+4. Next feature: `sqsk context` auto-injects prior learnings into planning
+5. Loop repeats with better information
+
+**Optional**: If enabled, the `after_implement` hook automatically runs `sqsk sync` to capture learnings.
+
+---
+
 10. **Check for extension hooks**: After completion validation, check if `.specify/extensions.yml` exists in the project root.
     - If it exists, read it and look for entries under the `hooks.after_implement` key
     - If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally

--- a/.github/agents/speckit.plan.agent.md
+++ b/.github/agents/speckit.plan.agent.md
@@ -69,6 +69,18 @@ You **MUST** consider the user input before proceeding (if not empty).
 
 4. **Stop and report**: Command ends after Phase 2 planning. Report branch, IMPL_PLAN path, and generated artifacts.
 
+## Bridge Integration: Context Injection & Continuity
+
+During planning, if bridge hooks are enabled, Squad context is automatically injected:
+
+- **squad-context.md** — Automatically generated (or can be manually triggered with `sqsk context`) to inject team decisions, skills, and learnings into your planning.
+- **How to use**: Review squad-context.md alongside your planning decisions to ensure alignment with prior work.
+- **If context is missing**: Run `sqsk context` manually to build the context file before proceeding, or continue planning without it (less optimal but still valid).
+
+**Bridge pipeline**: Spec (clarified) → Plan (informed by squad-context) → Tasks (generated from plan) → `sqsk issues` (convert to GitHub issues) → Squad execution → learnings sync back via bridge
+
+---
+
 5. **Check for extension hooks**: After reporting, check if `.specify/extensions.yml` exists in the project root.
    - If it exists, read it and look for entries under the `hooks.after_plan` key
    - If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally

--- a/.github/agents/speckit.specify.agent.md
+++ b/.github/agents/speckit.specify.agent.md
@@ -207,6 +207,19 @@ Given that feature description, do this:
 
 7. Report completion with branch name, spec file path, checklist results, and readiness for the next phase (`/speckit.clarify` or `/speckit.plan`).
 
+## Bridge Integration: Next Steps
+
+After specification is complete, the bridge enables automatic knowledge sharing with Squad:
+
+**When spec is ready**, you may optionally invoke the bridge to inject Squad context or prepare for Squad integration:
+
+- **`sqsk context`** — If Squad agents need context about this specification for future reference, run this command to build squad-context.md (automatic if bridge hooks are enabled).
+- **Expected flow**: Spec → Clarify (if needed) → Plan → Tasks → `sqsk issues` (convert to GitHub issues for Squad executor) → Squad execution → learnings feed back via bridge
+
+**Note**: If bridge hooks are enabled (check `.specify/extensions.yml`), Squad context injection happens automatically during planning. Manual invocation is only needed if you want immediate context generation.
+
+---
+
 8. **Check for extension hooks**: After reporting completion, check if `.specify/extensions.yml` exists in the project root.
    - If it exists, read it and look for entries under the `hooks.after_specify` key
    - If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally

--- a/.github/agents/speckit.tasks.agent.md
+++ b/.github/agents/speckit.tasks.agent.md
@@ -94,6 +94,30 @@ You **MUST** consider the user input before proceeding (if not empty).
    - Suggested MVP scope (typically just User Story 1)
    - Format validation: Confirm ALL tasks follow the checklist format (checkbox, ID, labels, file paths)
 
+## Bridge Integration: Issues Creation & Squad Handoff
+
+After tasks.md is generated, the bridge enables seamless handoff to Squad execution:
+
+**Next step in the pipeline**:
+1. **Review tasks** (optional): Run `/speckit.analyze` to validate task quality and consistency
+2. **Create GitHub issues** (recommended): Run `sqsk issues` to convert tasks.md into GitHub issues for assignment
+   - This command parses tasks.md and creates issues in your repository with:
+     - Issue title from task description
+     - Labels from task IDs and user story markers
+     - Dependency relationships mapped to issue links
+     - Ready for Squad Coordinator to assign to agents
+3. **Design Review** (optional): If enabled, run `/speckit.checklist` or manually review design decisions before execution
+
+**Why use `sqsk issues`?** 
+- Creates a bridge between SpecKit planning and Squad execution
+- Issues become the "contract" between planning and execution
+- Enables tracking, coordination, and knowledge capture during implementation
+- Learnings from execution automatically feed back to next planning cycle
+
+**If you skip `sqsk issues`**: You can proceed directly to implementation with tasks.md, but you lose Squad coordination and automated learning capture.
+
+---
+
 6. **Check for extension hooks**: After tasks.md is generated, check if `.specify/extensions.yml` exists in the project root.
    - If it exists, read it and look for entries under the `hooks.after_tasks` key
    - If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally

--- a/.github/agents/speckit.taskstoissues.agent.md
+++ b/.github/agents/speckit.taskstoissues.agent.md
@@ -28,3 +28,31 @@ git config --get remote.origin.url
 
 > [!CAUTION]
 > UNDER NO CIRCUMSTANCES EVER CREATE ISSUES IN REPOSITORIES THAT DO NOT MATCH THE REMOTE URL
+
+## Bridge Integration: From SpecKit Planning to Squad Execution
+
+This command is the **primary bridge** between SpecKit planning and Squad execution:
+
+**What this command does**:
+- Converts tasks.md (specification-driven task breakdown) into GitHub issues
+- Adds labels for traceability (Task IDs, User Story markers)
+- Maps dependencies as issue links
+- Creates "ready-to-assign" issues for Squad Coordinator
+
+**Why use this command** (`sqsk issues` or `/speckit.taskstoissues`):
+1. **Closes the loop** — Spec → Plan → Tasks → **Issues** (handoff point)
+2. **Enables Squad coordination** — Coordinator assigns issues to agents with clear acceptance criteria
+3. **Captures learnings** — Issues updated during execution feed insights back to next planning cycle
+4. **Maintains traceability** — Link from requirement (spec) → task (tasks.md) → issue → code commit → learnings
+
+**Pipeline**:
+1. Spec generated (`/speckit.specify`)
+2. Plan created (`/speckit.plan`, with automatic squad-context injection if bridge enabled)
+3. Tasks generated (`/speckit.tasks`)
+4. **Issues created** (this command: `/speckit.taskstoissues` = `sqsk issues`)
+5. Squad execution (Coordinator assigns, agents implement, document learnings)
+6. `sqsk sync` (learnings captured back to Squad memory)
+7. **Next cycle**: Planning benefits from prior learnings via squad-context injection
+
+**Expected outcome**: When this command completes, your team has GitHub issues ready for Squad assignment, with full traceability to planning artifacts.
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,20 @@
 {
-  "name": "squad-speckit-bridge",
-  "version": "0.1.0",
+  "name": "@jmservera/squad-speckit-bridge",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "squad-speckit-bridge",
-      "version": "0.1.0",
-      "license": "ISC",
+      "name": "@jmservera/squad-speckit-bridge",
+      "version": "0.2.0",
+      "license": "MIT",
       "dependencies": {
         "commander": "^14.0.3",
         "glob": "^13.0.6",
         "gray-matter": "^4.0.3"
       },
       "bin": {
+        "sqsk": "dist/cli/index.js",
         "squad-speckit-bridge": "dist/cli/index.js"
       },
       "devDependencies": {
@@ -21,6 +22,9 @@
         "tsx": "^4.21.0",
         "typescript": "^5.9.3",
         "vitest": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@emnapi/core": {
@@ -844,7 +848,6 @@
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -1611,7 +1614,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1809,7 +1811,6 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -1851,7 +1852,6 @@
       "integrity": "sha512-wt+Z2qIhfFt85uiyRt5LPU4oVEJBXj8hZNWKeqFG4gRG/0RaRGJ7njQCwzFVjO+v4+Ipmf5CY7VdmZRAYYBPHw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.3",


### PR DESCRIPTION
## Summary
Updated 9 SpecKit agent prompt files with explicit bridge command invocations:
- `sqsk issues` — after task generation
- `sqsk sync` — after implementation for learning capture
- `sqsk context` — before planning for Squad context injection

Documents the full circular pipeline: SpecKit → Squad → SpecKit feedback loop.

**9 files modified, 171 lines added.**

Closes #265

---
*Agent: 📝 Monica (T010) • Batch 5*