### PR TITLE
test(integration): add ArtifactValidator and CleanupHandler tests [T043+T044]

### DIFF
--- a/tests/integration/artifact-validator.test.ts
+++ b/tests/integration/artifact-validator.test.ts
@@ -1,0 +1,324 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdir, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { FileSystemArtifactValidator } from '../../src/demo/adapters/artifact-validator.js';
+import { ArtifactType, StageStatus } from '../../src/demo/entities.js';
+import type { PipelineStage, DemoConfiguration } from '../../src/demo/entities.js';
+
+/** Helper to build a minimal PipelineStage for testing */
+function makeStage(name: string, artifact: string): PipelineStage {
+  return {
+    name,
+    displayName: name,
+    command: [],
+    artifact,
+    status: StageStatus.Success,
+  };
+}
+
+/** Helper to build a minimal DemoConfiguration for testing */
+function makeConfig(demoDir: string): DemoConfiguration {
+  return {
+    exampleFeature: 'Test Feature',
+    demoDir,
+    flags: { dryRun: false, keep: false, verbose: false },
+    timeout: 30,
+    squadDir: '',
+    specifyDir: '',
+  };
+}
+
+/** Valid spec.md content with frontmatter and required sections */
+const VALID_SPEC = `---
+title: Test Spec
+version: "1.0"
+---
+
+## Overview
+
+This is the overview.
+
+## Requirements
+
+- Requirement 1
+`;
+
+/** Valid plan.md content */
+const VALID_PLAN = `---
+title: Test Plan
+---
+
+## Architecture
+
+Clean architecture layers.
+
+## Implementation
+
+Step-by-step plan.
+`;
+
+/** Valid tasks.md content */
+const VALID_TASKS = `---
+title: Test Tasks
+---
+
+## Tasks
+
+- [ ] Task 1
+`;
+
+/** Valid review.md content */
+const VALID_REVIEW = `---
+title: Test Review
+---
+
+## Summary
+
+All stages passed.
+`;
+
+describe('FileSystemArtifactValidator', () => {
+  let testDir: string;
+  let validator: FileSystemArtifactValidator;
+
+  beforeEach(async () => {
+    testDir = join(
+      tmpdir(),
+      `bridge-artifact-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    await mkdir(testDir, { recursive: true });
+    validator = new FileSystemArtifactValidator();
+  });
+
+  afterEach(async () => {
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  // ── Valid artifacts (all required files present) ───────────
+
+  describe('valid artifacts', () => {
+    it('validates a well-formed spec.md', async () => {
+      const filePath = join(testDir, 'spec.md');
+      await writeFile(filePath, VALID_SPEC);
+
+      const result = await validator.validate(filePath, makeStage('specify', 'spec.md'));
+
+      expect(result.exists).toBe(true);
+      expect(result.valid).toBe(true);
+      expect(result.errors).toEqual([]);
+      expect(result.type).toBe(ArtifactType.Spec);
+      expect(result.sizeBytes).toBeGreaterThan(0);
+    });
+
+    it('validates a well-formed plan.md', async () => {
+      const filePath = join(testDir, 'plan.md');
+      await writeFile(filePath, VALID_PLAN);
+
+      const result = await validator.validate(filePath, makeStage('plan', 'plan.md'));
+
+      expect(result.valid).toBe(true);
+      expect(result.type).toBe(ArtifactType.Plan);
+    });
+
+    it('validates a well-formed tasks.md', async () => {
+      const filePath = join(testDir, 'tasks.md');
+      await writeFile(filePath, VALID_TASKS);
+
+      const result = await validator.validate(filePath, makeStage('tasks', 'tasks.md'));
+
+      expect(result.valid).toBe(true);
+      expect(result.type).toBe(ArtifactType.Tasks);
+    });
+
+    it('validates a well-formed review.md', async () => {
+      const filePath = join(testDir, 'review.md');
+      await writeFile(filePath, VALID_REVIEW);
+
+      const result = await validator.validate(filePath, makeStage('review', 'review.md'));
+
+      expect(result.valid).toBe(true);
+      expect(result.type).toBe(ArtifactType.Review);
+    });
+
+    it('validates all artifacts in a directory via validateAll', async () => {
+      await writeFile(join(testDir, 'spec.md'), VALID_SPEC);
+      await writeFile(join(testDir, 'plan.md'), VALID_PLAN);
+      await writeFile(join(testDir, 'tasks.md'), VALID_TASKS);
+      await writeFile(join(testDir, 'review.md'), VALID_REVIEW);
+
+      const artifacts = await validator.validateAll(makeConfig(testDir));
+
+      expect(artifacts).toHaveLength(4);
+      expect(artifacts.every((a) => a.valid)).toBe(true);
+      expect(artifacts.every((a) => a.exists)).toBe(true);
+
+      const types = artifacts.map((a) => a.type).sort();
+      expect(types).toEqual(
+        [ArtifactType.Plan, ArtifactType.Review, ArtifactType.Spec, ArtifactType.Tasks].sort(),
+      );
+    });
+  });
+
+  // ── Missing artifacts ──────────────────────────────────────
+
+  describe('missing artifacts', () => {
+    it('reports missing file as invalid', async () => {
+      const filePath = join(testDir, 'nonexistent.md');
+
+      const result = await validator.validate(filePath, makeStage('specify', 'spec.md'));
+
+      expect(result.exists).toBe(false);
+      expect(result.valid).toBe(false);
+      expect(result.sizeBytes).toBe(0);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0]).toContain('does not exist');
+    });
+
+    it('returns empty array from validateAll on missing directory', async () => {
+      const missingDir = join(testDir, 'does-not-exist');
+
+      const artifacts = await validator.validateAll(makeConfig(missingDir));
+
+      expect(artifacts).toEqual([]);
+    });
+
+    it('only validates known artifact files in directory', async () => {
+      await writeFile(join(testDir, 'spec.md'), VALID_SPEC);
+      await writeFile(join(testDir, 'random.txt'), 'not an artifact');
+
+      const artifacts = await validator.validateAll(makeConfig(testDir));
+
+      expect(artifacts).toHaveLength(1);
+      expect(artifacts[0].type).toBe(ArtifactType.Spec);
+    });
+  });
+
+  // ── Corrupt / invalid artifact content ─────────────────────
+
+  describe('corrupt or invalid content', () => {
+    it('rejects file without frontmatter', async () => {
+      const filePath = join(testDir, 'spec.md');
+      await writeFile(filePath, '## Overview\n\n## Requirements\n');
+
+      const result = await validator.validate(filePath, makeStage('specify', 'spec.md'));
+
+      expect(result.exists).toBe(true);
+      expect(result.valid).toBe(false);
+      expect(result.errors.some((e) => e.includes('frontmatter'))).toBe(true);
+    });
+
+    it('rejects file with empty frontmatter', async () => {
+      const filePath = join(testDir, 'spec.md');
+      await writeFile(filePath, '---\n---\n\n## Overview\n\n## Requirements\n');
+
+      const result = await validator.validate(filePath, makeStage('specify', 'spec.md'));
+
+      expect(result.valid).toBe(false);
+      expect(result.errors.some((e) => e.includes('empty'))).toBe(true);
+    });
+
+    it('rejects spec.md missing required sections', async () => {
+      const filePath = join(testDir, 'spec.md');
+      await writeFile(filePath, '---\ntitle: Incomplete\n---\n\nNo sections here.\n');
+
+      const result = await validator.validate(filePath, makeStage('specify', 'spec.md'));
+
+      expect(result.valid).toBe(false);
+      expect(result.errors.some((e) => e.includes('## Overview'))).toBe(true);
+      expect(result.errors.some((e) => e.includes('## Requirements'))).toBe(true);
+    });
+
+    it('rejects plan.md missing required sections', async () => {
+      const filePath = join(testDir, 'plan.md');
+      await writeFile(filePath, '---\ntitle: Bad Plan\n---\n\nNothing useful.\n');
+
+      const result = await validator.validate(filePath, makeStage('plan', 'plan.md'));
+
+      expect(result.valid).toBe(false);
+      expect(result.errors.some((e) => e.includes('## Architecture'))).toBe(true);
+      expect(result.errors.some((e) => e.includes('## Implementation'))).toBe(true);
+    });
+
+    it('collects multiple errors in a single validation', async () => {
+      const filePath = join(testDir, 'spec.md');
+      // No frontmatter AND missing required sections
+      await writeFile(filePath, 'Just some text with no structure');
+
+      const result = await validator.validate(filePath, makeStage('specify', 'spec.md'));
+
+      expect(result.valid).toBe(false);
+      // Should have frontmatter error + section errors
+      expect(result.errors.length).toBeGreaterThanOrEqual(2);
+    });
+  });
+
+  // ── Empty directories ──────────────────────────────────────
+
+  describe('empty directories', () => {
+    it('returns empty array from validateAll on empty directory', async () => {
+      const emptyDir = join(testDir, 'empty');
+      await mkdir(emptyDir, { recursive: true });
+
+      const artifacts = await validator.validateAll(makeConfig(emptyDir));
+
+      expect(artifacts).toEqual([]);
+    });
+
+    it('validates zero-byte file as invalid', async () => {
+      const filePath = join(testDir, 'spec.md');
+      await writeFile(filePath, '');
+
+      const result = await validator.validate(filePath, makeStage('specify', 'spec.md'));
+
+      expect(result.exists).toBe(true);
+      expect(result.valid).toBe(false);
+      expect(result.errors.length).toBeGreaterThan(0);
+    });
+  });
+
+  // ── Artifact format / type mapping ─────────────────────────
+
+  describe('artifact format validation', () => {
+    it('maps spec.md filename to Spec type', async () => {
+      const filePath = join(testDir, 'spec.md');
+      await writeFile(filePath, VALID_SPEC);
+
+      const result = await validator.validate(filePath, makeStage('unknown', 'spec.md'));
+      expect(result.type).toBe(ArtifactType.Spec);
+    });
+
+    it('falls back to stage name when filename is unrecognized', async () => {
+      const filePath = join(testDir, 'output.md');
+      await writeFile(filePath, VALID_PLAN);
+
+      const result = await validator.validate(filePath, makeStage('plan', 'output.md'));
+      expect(result.type).toBe(ArtifactType.Plan);
+    });
+
+    it('defaults to Spec type for unknown filename and stage', async () => {
+      const filePath = join(testDir, 'mystery.md');
+      await writeFile(filePath, VALID_SPEC);
+
+      const result = await validator.validate(filePath, makeStage('unknown', 'mystery.md'));
+      expect(result.type).toBe(ArtifactType.Spec);
+    });
+
+    it('records file size accurately', async () => {
+      const content = 'x'.repeat(1234);
+      const filePath = join(testDir, 'spec.md');
+      await writeFile(filePath, content);
+
+      const result = await validator.validate(filePath, makeStage('specify', 'spec.md'));
+      expect(result.sizeBytes).toBe(1234);
+    });
+
+    it('preserves full path in result', async () => {
+      const filePath = join(testDir, 'spec.md');
+      await writeFile(filePath, VALID_SPEC);
+
+      const result = await validator.validate(filePath, makeStage('specify', 'spec.md'));
+      expect(result.path).toBe(filePath);
+    });
+  });
+});

--- a/tests/integration/cleanup-handler.test.ts
+++ b/tests/integration/cleanup-handler.test.ts
@@ -1,0 +1,372 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdir, rm, writeFile, stat, readdir, chmod } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+import { tmpdir } from 'node:os';
+import { FileSystemCleanupHandler } from '../../src/demo/adapters/cleanup-handler.js';
+import type { DemoConfiguration, ExecutionReport } from '../../src/demo/entities.js';
+
+/** Helper to build a DemoConfiguration pointing at a given demoDir */
+function makeConfig(
+  demoDir: string,
+  flags: { keep?: boolean } = {},
+): DemoConfiguration {
+  return {
+    exampleFeature: 'Test Feature',
+    demoDir,
+    flags: { dryRun: false, keep: flags.keep ?? false, verbose: false },
+    timeout: 30,
+    squadDir: '',
+    specifyDir: '',
+  };
+}
+
+/** Helper to build a minimal ExecutionReport */
+function makeReport(overrides: Partial<ExecutionReport> = {}): ExecutionReport {
+  return {
+    totalTimeMs: 100,
+    stagesCompleted: 4,
+    stagesFailed: 0,
+    artifacts: [],
+    cleanupPerformed: false,
+    ...overrides,
+  };
+}
+
+describe('FileSystemCleanupHandler', () => {
+  let handler: FileSystemCleanupHandler;
+  // Root temp dir for all specs/ subdirectories used in this suite
+  let rootDir: string;
+
+  beforeEach(async () => {
+    handler = new FileSystemCleanupHandler();
+    rootDir = join(
+      tmpdir(),
+      `bridge-cleanup-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    await mkdir(rootDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(rootDir, { recursive: true, force: true });
+  });
+
+  // ── Successful cleanup of temp directories ─────────────────
+
+  describe('successful cleanup', () => {
+    it('removes a demo directory and sets cleanupPerformed', async () => {
+      const specsDir = join(rootDir, 'specs');
+      const demoDir = join(specsDir, 'demo-test');
+      await mkdir(demoDir, { recursive: true });
+      await writeFile(join(demoDir, 'spec.md'), '# Spec');
+
+      // chdir so isSafeToDelete resolves relative to rootDir
+      const originalCwd = process.cwd();
+      process.chdir(rootDir);
+      try {
+        const result = await handler.cleanup(
+          makeConfig(demoDir),
+          makeReport(),
+        );
+
+        expect(result.cleanupPerformed).toBe(true);
+        await expect(stat(demoDir)).rejects.toThrow();
+      } finally {
+        process.chdir(originalCwd);
+      }
+    });
+
+    it('skips cleanup when keep flag is true', async () => {
+      const specsDir = join(rootDir, 'specs');
+      const demoDir = join(specsDir, 'demo-keep');
+      await mkdir(demoDir, { recursive: true });
+      await writeFile(join(demoDir, 'plan.md'), '# Plan');
+
+      const originalCwd = process.cwd();
+      process.chdir(rootDir);
+      try {
+        const result = await handler.cleanup(
+          makeConfig(demoDir, { keep: true }),
+          makeReport(),
+        );
+
+        expect(result.cleanupPerformed).toBe(false);
+        // Directory should still exist
+        const stats = await stat(demoDir);
+        expect(stats.isDirectory()).toBe(true);
+      } finally {
+        process.chdir(originalCwd);
+      }
+    });
+
+    it('preserves existing errorSummary when cleanup is skipped', async () => {
+      const specsDir = join(rootDir, 'specs');
+      const demoDir = join(specsDir, 'demo-err');
+      await mkdir(demoDir, { recursive: true });
+
+      const originalCwd = process.cwd();
+      process.chdir(rootDir);
+      try {
+        const result = await handler.cleanup(
+          makeConfig(demoDir, { keep: true }),
+          makeReport({ errorSummary: 'Stage 2 failed' }),
+        );
+
+        expect(result.cleanupPerformed).toBe(false);
+        expect(result.errorSummary).toBe('Stage 2 failed');
+      } finally {
+        process.chdir(originalCwd);
+      }
+    });
+  });
+
+  // ── Permission / unsafe path errors ────────────────────────
+
+  describe('path safety and permission errors', () => {
+    it('refuses to delete directories outside specs/', async () => {
+      const unsafeDir = join(rootDir, 'not-specs', 'demo');
+      await mkdir(unsafeDir, { recursive: true });
+
+      const originalCwd = process.cwd();
+      process.chdir(rootDir);
+      try {
+        const result = await handler.cleanup(
+          makeConfig(unsafeDir),
+          makeReport(),
+        );
+
+        expect(result.cleanupPerformed).toBe(false);
+        expect(result.errorSummary).toContain('not safe to delete');
+      } finally {
+        process.chdir(originalCwd);
+      }
+    });
+
+    it('refuses paths with parent traversal (..)', async () => {
+      const traversalPath = join(rootDir, 'specs', '..', 'etc');
+
+      const originalCwd = process.cwd();
+      process.chdir(rootDir);
+      try {
+        const isSafe = await handler.isSafeToDelete(traversalPath);
+        expect(isSafe).toBe(false);
+      } finally {
+        process.chdir(originalCwd);
+      }
+    });
+
+    it('appends cleanup error to existing errorSummary', async () => {
+      const unsafeDir = join(rootDir, 'outside', 'demo');
+      await mkdir(unsafeDir, { recursive: true });
+
+      const originalCwd = process.cwd();
+      process.chdir(rootDir);
+      try {
+        const result = await handler.cleanup(
+          makeConfig(unsafeDir),
+          makeReport({ errorSummary: 'Previous error' }),
+        );
+
+        expect(result.cleanupPerformed).toBe(false);
+        expect(result.errorSummary).toContain('Previous error');
+        expect(result.errorSummary).toContain('not safe to delete');
+      } finally {
+        process.chdir(originalCwd);
+      }
+    });
+  });
+
+  // ── Nested directories ─────────────────────────────────────
+
+  describe('nested directories', () => {
+    it('recursively removes deeply nested structures', async () => {
+      const specsDir = join(rootDir, 'specs');
+      const demoDir = join(specsDir, 'demo-nested');
+      const deepDir = join(demoDir, 'level1', 'level2', 'level3');
+      await mkdir(deepDir, { recursive: true });
+      await writeFile(join(deepDir, 'deep-file.md'), 'deep content');
+      await writeFile(join(demoDir, 'top-file.md'), 'top content');
+      await writeFile(join(demoDir, 'level1', 'mid-file.md'), 'mid content');
+
+      const originalCwd = process.cwd();
+      process.chdir(rootDir);
+      try {
+        const result = await handler.cleanup(
+          makeConfig(demoDir),
+          makeReport(),
+        );
+
+        expect(result.cleanupPerformed).toBe(true);
+        await expect(stat(demoDir)).rejects.toThrow();
+      } finally {
+        process.chdir(originalCwd);
+      }
+    });
+
+    it('removes directory with mixed files and subdirectories', async () => {
+      const specsDir = join(rootDir, 'specs');
+      const demoDir = join(specsDir, 'demo-mixed');
+      const subDir = join(demoDir, 'sub');
+      await mkdir(subDir, { recursive: true });
+      await writeFile(join(demoDir, 'spec.md'), '# Spec');
+      await writeFile(join(demoDir, 'plan.md'), '# Plan');
+      await writeFile(join(subDir, 'notes.txt'), 'notes');
+
+      const originalCwd = process.cwd();
+      process.chdir(rootDir);
+      try {
+        const result = await handler.cleanup(
+          makeConfig(demoDir),
+          makeReport(),
+        );
+
+        expect(result.cleanupPerformed).toBe(true);
+        await expect(stat(demoDir)).rejects.toThrow();
+        // Parent specs/ dir should still exist
+        const parentStats = await stat(specsDir);
+        expect(parentStats.isDirectory()).toBe(true);
+      } finally {
+        process.chdir(originalCwd);
+      }
+    });
+  });
+
+  // ── Directory doesn't exist ────────────────────────────────
+
+  describe('non-existent directories', () => {
+    it('isSafeToDelete returns false for missing directory', async () => {
+      const missing = join(rootDir, 'specs', 'ghost');
+
+      const originalCwd = process.cwd();
+      process.chdir(rootDir);
+      try {
+        const result = await handler.isSafeToDelete(missing);
+        expect(result).toBe(false);
+      } finally {
+        process.chdir(originalCwd);
+      }
+    });
+
+    it('cleanup reports path-not-safe when directory is missing', async () => {
+      const missing = join(rootDir, 'specs', 'ghost');
+
+      const originalCwd = process.cwd();
+      process.chdir(rootDir);
+      try {
+        const result = await handler.cleanup(
+          makeConfig(missing),
+          makeReport(),
+        );
+
+        expect(result.cleanupPerformed).toBe(false);
+      } finally {
+        process.chdir(originalCwd);
+      }
+    });
+
+    it('isSafeToDelete returns false for a file (not a directory)', async () => {
+      const specsDir = join(rootDir, 'specs');
+      await mkdir(specsDir, { recursive: true });
+      const filePath = join(specsDir, 'not-a-dir.md');
+      await writeFile(filePath, 'content');
+
+      const originalCwd = process.cwd();
+      process.chdir(rootDir);
+      try {
+        const result = await handler.isSafeToDelete(filePath);
+        expect(result).toBe(false);
+      } finally {
+        process.chdir(originalCwd);
+      }
+    });
+  });
+
+  // ── Selective cleanup (keep some, remove others) ───────────
+
+  describe('selective cleanup', () => {
+    it('cleans one demo dir while leaving another intact', async () => {
+      const specsDir = join(rootDir, 'specs');
+      const demoA = join(specsDir, 'demo-a');
+      const demoB = join(specsDir, 'demo-b');
+      await mkdir(demoA, { recursive: true });
+      await mkdir(demoB, { recursive: true });
+      await writeFile(join(demoA, 'spec.md'), '# A');
+      await writeFile(join(demoB, 'spec.md'), '# B');
+
+      const originalCwd = process.cwd();
+      process.chdir(rootDir);
+      try {
+        // Clean demo-a only
+        const result = await handler.cleanup(
+          makeConfig(demoA),
+          makeReport(),
+        );
+
+        expect(result.cleanupPerformed).toBe(true);
+        await expect(stat(demoA)).rejects.toThrow();
+
+        // demo-b should be untouched
+        const bStats = await stat(demoB);
+        expect(bStats.isDirectory()).toBe(true);
+        const bFiles = await readdir(demoB);
+        expect(bFiles).toContain('spec.md');
+      } finally {
+        process.chdir(originalCwd);
+      }
+    });
+
+    it('keep=true preserves directory while keep=false removes it', async () => {
+      const specsDir = join(rootDir, 'specs');
+      const keepDir = join(specsDir, 'demo-keep');
+      const removeDir = join(specsDir, 'demo-remove');
+      await mkdir(keepDir, { recursive: true });
+      await mkdir(removeDir, { recursive: true });
+      await writeFile(join(keepDir, 'spec.md'), '# Keep');
+      await writeFile(join(removeDir, 'spec.md'), '# Remove');
+
+      const originalCwd = process.cwd();
+      process.chdir(rootDir);
+      try {
+        // Keep
+        const keepResult = await handler.cleanup(
+          makeConfig(keepDir, { keep: true }),
+          makeReport(),
+        );
+        expect(keepResult.cleanupPerformed).toBe(false);
+
+        // Remove
+        const removeResult = await handler.cleanup(
+          makeConfig(removeDir),
+          makeReport(),
+        );
+        expect(removeResult.cleanupPerformed).toBe(true);
+
+        // Kept dir still exists
+        const keepStats = await stat(keepDir);
+        expect(keepStats.isDirectory()).toBe(true);
+
+        // Removed dir is gone
+        await expect(stat(removeDir)).rejects.toThrow();
+      } finally {
+        process.chdir(originalCwd);
+      }
+    });
+
+    it('isSafeToDelete accepts specs/ subdirectories only', async () => {
+      const specsDir = join(rootDir, 'specs');
+      const safeDir = join(specsDir, 'demo-safe');
+      const unsafeSrc = join(rootDir, 'src');
+      await mkdir(safeDir, { recursive: true });
+      await mkdir(unsafeSrc, { recursive: true });
+
+      const originalCwd = process.cwd();
+      process.chdir(rootDir);
+      try {
+        expect(await handler.isSafeToDelete(safeDir)).toBe(true);
+        expect(await handler.isSafeToDelete(unsafeSrc)).toBe(false);
+        expect(await handler.isSafeToDelete(rootDir)).toBe(false);
+      } finally {
+        process.chdir(originalCwd);
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Two integration test suites:
- **T043 ArtifactValidator** (20 tests): valid artifacts, missing artifacts, corrupt content, empty dirs, format validation
- **T044 CleanupHandler** (14 tests): successful cleanup, path safety, nested dirs, non-existent dirs, selective cleanup

**34 new tests, 217 total passing.**

Closes #247, closes #248

---
*Agent: 🧪 Jared (T043+T044) • Batch 7*