### PR TITLE
feat(cli): add --dry-run flag with full pipeline support [T018-T022]

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -25,6 +25,7 @@ program
   )
   .version('0.2.0')
   .option('--config <path>', 'Path to bridge configuration file')
+  .option('-n, --dry-run', 'Prevent all write operations (preview mode)', false)
   .option('--json', 'Output in JSON format', false)
   .option('--quiet', 'Suppress informational output', false)
   .option('--verbose', 'Enable verbose output', false);
@@ -88,6 +89,7 @@ program
     const globalOpts = program.opts();
     const jsonOutput = globalOpts.json as boolean;
     const quiet = globalOpts.quiet as boolean;
+    const dryRun = globalOpts.dryRun as boolean;
 
     try {
       const installer = createInstaller({
@@ -96,7 +98,7 @@ program
         specifyDir: cmdOpts.specifyDir as string | undefined,
       });
 
-      const result = await installer.install({ force: cmdOpts.force as boolean });
+      const result = await installer.install({ force: cmdOpts.force as boolean, dryRun });
 
       if (jsonOutput) {
         console.log(JSON.stringify(result.jsonOutput, null, 2));
@@ -130,6 +132,7 @@ program
     const globalOpts = program.opts();
     const jsonOutput = globalOpts.json as boolean;
     const quiet = globalOpts.quiet as boolean;
+    const dryRun = globalOpts.dryRun as boolean;
 
     try {
       const sourcesList = (cmdOpts.sources as string).split(',').map((s: string) => s.trim());
@@ -143,6 +146,7 @@ program
           decisions: sourcesList.includes('decisions'),
           histories: sourcesList.includes('histories'),
         },
+        dryRun,
       });
 
       const result = await builder.build();
@@ -169,13 +173,14 @@ program
     const globalOpts = program.opts();
     const jsonOutput = globalOpts.json as boolean;
     const quiet = globalOpts.quiet as boolean;
+    const dryRun = globalOpts.dryRun as boolean;
 
     try {
       const checker = createStatusChecker({
         configPath: globalOpts.config as string | undefined,
       });
 
-      const result = await checker.check();
+      const result = await checker.check({ dryRun });
 
       if (jsonOutput) {
         console.log(JSON.stringify(result.jsonOutput, null, 2));
@@ -206,6 +211,7 @@ program
     const jsonOutput = globalOpts.json as boolean;
     const quiet = globalOpts.quiet as boolean;
     const notify = cmdOpts.notify as boolean;
+    const dryRun = globalOpts.dryRun as boolean;
 
     // T038: --notify mode — lightweight notification without full review
     if (notify) {
@@ -232,6 +238,7 @@ program
       const result = await reviewer.review(
         tasksFile,
         cmdOpts.output as string | undefined,
+        { dryRun },
       );
 
       if (jsonOutput) {
@@ -263,6 +270,7 @@ program
     const jsonOutput = globalOpts.json as boolean;
     const quiet = globalOpts.quiet as boolean;
     const verbose = globalOpts.verbose as boolean;
+    const dryRun = (globalOpts.dryRun as boolean) || (cmdOpts.dryRun as boolean);
     const logger = createLogger({ verbose, quiet });
 
     try {
@@ -275,7 +283,7 @@ program
       const labels = (cmdOpts.labels as string).split(',').map((l: string) => l.trim());
 
       const result = await creator.createFromTasks(tasksFile, {
-        dryRun: cmdOpts.dryRun as boolean,
+        dryRun,
         labels,
         repository: cmdOpts.repo as string | undefined,
       });
@@ -309,6 +317,7 @@ program
     const jsonOutput = globalOpts.json as boolean;
     const quiet = globalOpts.quiet as boolean;
     const verbose = globalOpts.verbose as boolean;
+    const dryRun = (globalOpts.dryRun as boolean) || (cmdOpts.dryRun as boolean);
     const logger = createLogger({ verbose, quiet });
 
     try {
@@ -319,7 +328,7 @@ program
       });
 
       const result = await syncer.sync(specDir, {
-        dryRun: cmdOpts.dryRun as boolean,
+        dryRun,
       });
 
       logger.verbose(`Sync complete: ${result.jsonOutput.record.learningsUpdated} learnings`);
@@ -350,6 +359,7 @@ program
     const globalOpts = program.opts();
     const jsonOutput = (cmdOpts.json as boolean) || (globalOpts.json as boolean);
     const verbose = (cmdOpts.verbose as boolean) || (globalOpts.verbose as boolean);
+    const dryRun = (globalOpts.dryRun as boolean) || (cmdOpts.dryRun as boolean);
     const logger = createLogger({ verbose, quiet: globalOpts.quiet as boolean });
 
     try {
@@ -360,7 +370,7 @@ program
         exampleFeature: 'User Authentication with OAuth2 and JWT tokens',
         demoDir,
         flags: {
-          dryRun: cmdOpts.dryRun as boolean,
+          dryRun,
           keep: cmdOpts.keep as boolean,
           verbose,
         },

--- a/src/main.ts
+++ b/src/main.ts
@@ -47,6 +47,7 @@ export interface InstallerOptions {
 export interface InstallOutput {
   humanOutput: string;
   jsonOutput: {
+    dryRun: boolean;
     version: string;
     frameworks: {
       squad: { detected: boolean; path: string };
@@ -59,7 +60,7 @@ export interface InstallOutput {
 
 export interface StatusOutput {
   humanOutput: string;
-  jsonOutput: StatusReport;
+  jsonOutput: StatusReport & { dryRun: boolean };
 }
 
 export interface ReviewerOptions {
@@ -71,6 +72,7 @@ export interface ReviewerOptions {
 export interface ReviewOutput {
   humanOutput: string;
   jsonOutput: {
+    dryRun: boolean;
     reviewedArtifact: string;
     timestamp: string;
     approvalStatus: string;
@@ -90,12 +92,53 @@ export function createInstaller(options: InstallerOptions = {}) {
   });
 
   return {
-    async install(opts: { force?: boolean } = {}): Promise<InstallOutput> {
+    async install(opts: { force?: boolean; dryRun?: boolean } = {}): Promise<InstallOutput> {
       const config = await configLoader.load();
+      const dryRun = opts.dryRun ?? false;
 
       // Apply CLI overrides
       if (options.squadDir) config.paths.squadDir = options.squadDir;
       if (options.specifyDir) config.paths.specifyDir = options.specifyDir;
+
+      if (dryRun) {
+        // Dry-run: detect frameworks but skip file deployment
+        const hasSquad = await detector.detectSquad(config.paths.squadDir);
+        const hasSpecKit = await detector.detectSpecKit(config.paths.specifyDir);
+
+        const wouldInstall: string[] = [];
+        if (hasSquad) wouldInstall.push(`${config.paths.squadDir}/skills/bridge-integration.md`);
+        if (hasSpecKit) {
+          wouldInstall.push(`${config.paths.specifyDir}/extensions/squad-bridge.yml`);
+          wouldInstall.push(`${config.paths.specifyDir}/ceremonies/design-review.md`);
+        }
+
+        const humanOutput = formatInstallHuman(
+          {
+            version: '0.2.0',
+            installedAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+            components: { squadSkill: hasSquad, specKitExtension: hasSpecKit, ceremonyDef: hasSpecKit },
+            files: wouldInstall,
+          },
+          [],
+          config,
+          true,
+        );
+        const jsonOutput = formatInstallJson(
+          {
+            version: '0.2.0',
+            installedAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+            components: { squadSkill: hasSquad, specKitExtension: hasSpecKit, ceremonyDef: hasSpecKit },
+            files: wouldInstall,
+          },
+          [],
+          config,
+          true,
+        );
+
+        return { humanOutput, jsonOutput };
+      }
 
       // Load templates (including hooks)
       const [skillTemplate, ceremonyTemplate, extensionTemplate, afterTasksHook, beforeSpecifyHook, afterImplementHook] =
@@ -124,8 +167,8 @@ export function createInstaller(options: InstallerOptions = {}) {
         { config, force: opts.force },
       );
 
-      const humanOutput = formatInstallHuman(result.manifest, result.warnings, config);
-      const jsonOutput = formatInstallJson(result.manifest, result.warnings, config);
+      const humanOutput = formatInstallHuman(result.manifest, result.warnings, config, false);
+      const jsonOutput = formatInstallJson(result.manifest, result.warnings, config, false);
 
       return { humanOutput, jsonOutput };
     },
@@ -144,14 +187,15 @@ export function createStatusChecker(
   });
 
   return {
-    async check(): Promise<StatusOutput> {
+    async check(opts: { dryRun?: boolean } = {}): Promise<StatusOutput> {
+      const dryRun = opts.dryRun ?? false;
       const config = await configLoader.load();
       const squadDirPath = resolve(baseDir, config.paths.squadDir);
       const squadReader = new SquadFileReader(squadDirPath);
       const report = await checkStatus(detector, deployer, configLoader, squadReader);
       return {
-        humanOutput: formatStatusHuman(report),
-        jsonOutput: report,
+        humanOutput: formatStatusHuman(report, dryRun),
+        jsonOutput: { ...report, dryRun },
       };
     },
   };
@@ -170,8 +214,10 @@ export function createReviewer(options: ReviewerOptions = {}) {
     async review(
       tasksFile: string,
       outputPath?: string,
+      opts: { dryRun?: boolean } = {},
     ): Promise<ReviewOutput> {
       const config = await configLoader.load();
+      const dryRun = opts.dryRun ?? false;
 
       // Apply CLI override
       const squadDir = options.squadDir ?? config.paths.squadDir;
@@ -184,11 +230,13 @@ export function createReviewer(options: ReviewerOptions = {}) {
         tasksFilePath: tasksFile,
       });
 
-      await reviewWriter.write(record, resolvedOutputPath);
+      if (!dryRun) {
+        await reviewWriter.write(record, resolvedOutputPath);
+      }
 
       return {
-        humanOutput: formatReviewHuman(record, resolvedOutputPath),
-        jsonOutput: formatReviewJson(record, resolvedOutputPath),
+        humanOutput: formatReviewHuman(record, resolvedOutputPath, dryRun),
+        jsonOutput: formatReviewJson(record, resolvedOutputPath, dryRun),
       };
     },
   };
@@ -302,9 +350,11 @@ function formatInstallHuman(
   manifest: InstallManifest,
   warnings: string[],
   config: { paths: { squadDir: string; specifyDir: string } },
+  dryRun: boolean,
 ): string {
   const lines: string[] = [];
-  lines.push(`Squad-SpecKit Bridge v${manifest.version}`);
+  const prefix = dryRun ? '[DRY RUN] ' : '';
+  lines.push(`${prefix}Squad-SpecKit Bridge v${manifest.version}`);
   lines.push('');
   lines.push('Detecting frameworks...');
 
@@ -325,19 +375,25 @@ function formatInstallHuman(
   const isPartial =
     !manifest.components.squadSkill || !manifest.components.specKitExtension;
   if (isPartial) {
-    lines.push('Installing partial components...');
+    lines.push(`${prefix}Installing partial components...`);
   } else {
-    lines.push('Installing components...');
+    lines.push(`${prefix}Installing components...`);
   }
 
   for (const file of manifest.files) {
-    lines.push(`  ✓ ${file}`);
+    lines.push(`  ${dryRun ? '•' : '✓'} ${file}`);
   }
-  lines.push(`  ✓ Manifest: .bridge-manifest.json`);
+  if (!dryRun) {
+    lines.push(`  ✓ Manifest: .bridge-manifest.json`);
+  }
 
   lines.push('');
 
-  if (isPartial) {
+  if (dryRun) {
+    lines.push(
+      `${prefix}Would install ${manifest.files.length} files. No changes were made.`,
+    );
+  } else if (isPartial) {
     lines.push(
       `Partial installation complete. ${manifest.files.length} files created.`,
     );
@@ -372,8 +428,10 @@ function formatInstallJson(
   manifest: InstallManifest,
   warnings: string[],
   config: { paths: { squadDir: string; specifyDir: string } },
+  dryRun: boolean,
 ) {
   return {
+    dryRun,
     version: manifest.version,
     frameworks: {
       squad: {
@@ -390,9 +448,10 @@ function formatInstallJson(
   };
 }
 
-function formatStatusHuman(report: StatusReport): string {
+function formatStatusHuman(report: StatusReport, dryRun: boolean): string {
   const lines: string[] = [];
-  lines.push(`Squad-SpecKit Bridge v${report.version}`);
+  const prefix = dryRun ? '[DRY RUN] ' : '';
+  lines.push(`${prefix}Squad-SpecKit Bridge v${report.version}`);
   lines.push('');
   lines.push('Frameworks:');
   lines.push(
@@ -468,11 +527,13 @@ export interface ContextBuilderOptions {
     histories: boolean;
   };
   baseDir?: string;
+  dryRun?: boolean;
 }
 
 export interface ContextOutput {
   humanOutput: string;
   jsonOutput: {
+    dryRun: boolean;
     output: string;
     sizeBytes: number;
     maxBytes: number;
@@ -496,6 +557,7 @@ export function createContextBuilder(options: ContextBuilderOptions) {
   return {
     async build(): Promise<ContextOutput> {
       const config = await configLoader.load();
+      const dryRun = options.dryRun ?? false;
 
       // Apply CLI overrides
       if (options.squadDir) config.paths.squadDir = options.squadDir;
@@ -508,15 +570,23 @@ export function createContextBuilder(options: ContextBuilderOptions) {
       const specDirPath = resolve(baseDir, options.specDir);
 
       const reader = new SquadFileReader(squadDirPath);
-      const writer = new SpecKitContextWriter(specDirPath);
+      const realWriter = new SpecKitContextWriter(specDirPath);
+
+      // In dry-run mode, wrap the writer to skip the actual file write
+      const writer = dryRun
+        ? {
+            write: async () => {},
+            readPreviousMetadata: () => realWriter.readPreviousMetadata(),
+          }
+        : realWriter;
 
       const { summary } = await buildSquadContext(reader, writer, { config });
 
       const outputPath = `${options.specDir}/squad-context.md`;
       const readerWarnings = reader.getWarnings();
 
-      const humanOutput = formatContextHuman(summary, outputPath, readerWarnings);
-      const jsonOutput = formatContextJson(summary, outputPath, readerWarnings);
+      const humanOutput = formatContextHuman(summary, outputPath, readerWarnings, dryRun);
+      const jsonOutput = formatContextJson(summary, outputPath, readerWarnings, dryRun);
 
       return { humanOutput, jsonOutput };
     },
@@ -527,11 +597,13 @@ function formatContextHuman(
   summary: ContextSummary,
   outputPath: string,
   parseWarnings: { file: string; reason: string }[],
+  dryRun: boolean,
 ): string {
   const lines: string[] = [];
   const m = summary.metadata;
+  const prefix = dryRun ? '[DRY RUN] ' : '';
 
-  lines.push(`Generating Squad context...`);
+  lines.push(`${prefix}Generating Squad context...`);
   lines.push('');
   lines.push('Sources processed:');
   lines.push(`  Skills:    ${m.sources.skills} included`);
@@ -551,9 +623,15 @@ function formatContextHuman(
   }
 
   lines.push('');
-  lines.push(
-    `Output: ${outputPath} (${(m.sizeBytes / 1024).toFixed(1)}KB / ${(m.maxBytes / 1024).toFixed(1)}KB limit)`,
-  );
+  if (dryRun) {
+    lines.push(
+      `${prefix}Would write: ${outputPath} (${(m.sizeBytes / 1024).toFixed(1)}KB / ${(m.maxBytes / 1024).toFixed(1)}KB limit). No changes were made.`,
+    );
+  } else {
+    lines.push(
+      `Output: ${outputPath} (${(m.sizeBytes / 1024).toFixed(1)}KB / ${(m.maxBytes / 1024).toFixed(1)}KB limit)`,
+    );
+  }
 
   return lines.join('\n');
 }
@@ -561,9 +639,11 @@ function formatContextHuman(
 function formatReviewHuman(
   record: DesignReviewRecord,
   outputPath: string,
+  dryRun: boolean,
 ): string {
   const lines: string[] = [];
-  lines.push(`Design Review prepared for ${record.reviewedArtifact}`);
+  const prefix = dryRun ? '[DRY RUN] ' : '';
+  lines.push(`${prefix}Design Review prepared for ${record.reviewedArtifact}`);
   lines.push('');
   lines.push('Pre-populated findings:');
   const high = record.findings.filter((f) => f.severity === 'high').length;
@@ -577,8 +657,12 @@ function formatReviewHuman(
     lines.push('  ✓ No issues detected');
   }
   lines.push('');
-  lines.push(`Review template written to: ${outputPath}`);
-  lines.push('Next: Run the Design Review ceremony with your Squad team.');
+  if (dryRun) {
+    lines.push(`${prefix}Would write review to: ${outputPath}. No changes were made.`);
+  } else {
+    lines.push(`Review template written to: ${outputPath}`);
+    lines.push('Next: Run the Design Review ceremony with your Squad team.');
+  }
 
   return lines.join('\n');
 }
@@ -587,6 +671,7 @@ function formatContextJson(
   summary: ContextSummary,
   outputPath: string,
   parseWarnings: { file: string; reason: string }[],
+  dryRun: boolean,
 ) {
   const m = summary.metadata;
 
@@ -615,6 +700,7 @@ function formatContextJson(
   );
 
   return {
+    dryRun,
     output: outputPath,
     sizeBytes: m.sizeBytes,
     maxBytes: m.maxBytes,
@@ -640,11 +726,12 @@ function formatContextJson(
   };
 }
 
-function formatReviewJson(record: DesignReviewRecord, outputPath: string) {
+function formatReviewJson(record: DesignReviewRecord, outputPath: string, dryRun: boolean) {
   const high = record.findings.filter((f) => f.severity === 'high').length;
   const medium = record.findings.filter((f) => f.severity === 'medium').length;
   const low = record.findings.filter((f) => f.severity === 'low').length;
   return {
+    dryRun,
     reviewedArtifact: record.reviewedArtifact,
     timestamp: record.timestamp,
     approvalStatus: record.approvalStatus,
@@ -671,7 +758,7 @@ function formatIssuesHuman(
   lines.push('');
 
   if (created.length > 0) {
-    lines.push(`${prefix}Created issues:`);
+    lines.push(`${prefix}${dryRun ? 'Would create issues:' : 'Created issues:'}`);
     for (const issue of created) {
       if (dryRun) {
         lines.push(`  • ${issue.title} [${issue.labels.join(', ')}]`);
@@ -679,6 +766,10 @@ function formatIssuesHuman(
         lines.push(`  ✓ #${issue.issueNumber}: ${issue.title}`);
         if (issue.url) lines.push(`    ${issue.url}`);
       }
+    }
+    if (dryRun) {
+      lines.push('');
+      lines.push(`${prefix}No changes were made.`);
     }
   } else {
     lines.push('No eligible tasks to create issues for.');
@@ -701,6 +792,11 @@ function formatSyncHuman(record: SyncRecord, dryRun: boolean): string {
     for (const file of record.filesWritten) {
       lines.push(`  ✓ ${file}`);
     }
+  }
+
+  if (dryRun) {
+    lines.push('');
+    lines.push(`${prefix}No changes were made.`);
   }
 
   return lines.join('\n');

--- a/tests/unit/dry-run-output.test.ts
+++ b/tests/unit/dry-run-output.test.ts
@@ -1,0 +1,264 @@
+/**
+ * T018-T022: Dry-Run Output Formatting Tests
+ *
+ * Tests the composition root formatters (main.ts) for dry-run behavior:
+ *   - Install, Status, Context, Review, Issues, Sync human output with [DRY RUN]
+ *   - JSON output with dryRun field
+ *   - Write-skip behavior for install, context, review
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import {
+  createIssueCreator,
+  createSyncer,
+  createReviewer,
+  type IssuesOutput,
+  type SyncOutput,
+  type ReviewOutput,
+} from '../../src/main.js';
+
+// ─────────────────────────────────────────────────────────────
+// Mock adapters to isolate from file system
+// ─────────────────────────────────────────────────────────────
+
+vi.mock('../../src/install/adapters/config-loader.js', () => {
+  const mockLoad = vi.fn().mockResolvedValue({
+    contextMaxBytes: 8192,
+    sources: { skills: true, decisions: true, histories: true },
+    summarization: { recencyBiasWeight: 0.7, maxDecisionAgeDays: 90 },
+    hooks: { afterTasks: true, beforeSpecify: true, afterImplement: true },
+    sync: { autoSync: false, targetDir: '.squad' },
+    issues: { defaultLabels: ['squad', 'speckit'], repository: 'test/repo' },
+    paths: { squadDir: '.squad', specifyDir: '.specify' },
+  });
+  return {
+    ConfigFileLoader: class {
+      load = mockLoad;
+    },
+  };
+});
+
+vi.mock('../../src/issues/task-parser.js', () => ({
+  TasksMarkdownParser: class {
+    readAndParse = vi.fn().mockResolvedValue([
+      { id: 'T001', title: 'Setup', description: 'Setup — init', dependencies: [], status: 'pending' },
+      { id: 'T002', title: 'Build', description: 'Build — compile', dependencies: ['T001'], status: 'pending' },
+      { id: 'T003', title: 'Done', description: 'Done task', dependencies: [], status: 'done' },
+    ]);
+  },
+}));
+
+vi.mock('../../src/issues/adapters/github-issue-adapter.js', () => {
+  let counter = 100;
+  return {
+    GitHubIssueAdapter: class {
+      create = vi.fn().mockImplementation(async (task: { id: string; title: string; description: string }) => ({
+        issueNumber: counter++,
+        title: `${task.id}: ${task.title}`,
+        body: task.description,
+        labels: ['squad'],
+        taskId: task.id,
+        url: `https://github.com/test/repo/issues/${counter - 1}`,
+        createdAt: new Date().toISOString(),
+      }));
+      createBatch = vi.fn().mockResolvedValue([]);
+    },
+  };
+});
+
+vi.mock('../../src/sync/adapters/sync-state-adapter.js', () => ({
+  SyncStateAdapter: class {
+    readSyncState = vi.fn().mockResolvedValue(null);
+    writeSyncState = vi.fn().mockResolvedValue(undefined);
+    readSpecResults = vi.fn().mockResolvedValue([
+      { title: 'Learning 1', content: 'Content A' },
+    ]);
+    writeLearning = vi.fn().mockResolvedValue('.squad/agents/bridge/history.md');
+    writeDecision = vi.fn().mockResolvedValue('.squad/decisions.md');
+  },
+}));
+
+vi.mock('../../src/review/adapters/tasks-parser.js', () => ({
+  TasksParser: class {
+    readTasks = vi.fn().mockResolvedValue([
+      { id: 'T001', title: 'Task 1', description: 'A task', dependencies: [], status: 'pending' },
+    ]);
+  },
+}));
+
+vi.mock('../../src/review/adapters/review-writer.js', () => ({
+  ReviewWriter: class {
+    write = vi.fn().mockResolvedValue(undefined);
+  },
+}));
+
+vi.mock('../../src/bridge/adapters/squad-file-reader.js', () => ({
+  SquadFileReader: class {
+    readSkills = vi.fn().mockResolvedValue([]);
+    readDecisions = vi.fn().mockResolvedValue([]);
+    readLearnings = vi.fn().mockResolvedValue([]);
+    getWarnings = vi.fn().mockReturnValue([]);
+  },
+}));
+
+vi.mock('../../src/review/ceremony.js', () => ({
+  prepareReview: vi.fn().mockResolvedValue({
+    record: {
+      reviewedArtifact: 'tasks.md',
+      timestamp: '2025-07-01T00:00:00Z',
+      participants: ['bridge'],
+      findings: [],
+      approvalStatus: 'approved',
+      summary: 'No issues found',
+    },
+  }),
+}));
+
+// ─────────────────────────────────────────────────────────────
+// Issues output tests
+// ─────────────────────────────────────────────────────────────
+
+describe('Issues dry-run output formatting', () => {
+  it('human output contains [DRY RUN] prefix when dryRun=true', async () => {
+    const creator = createIssueCreator({ baseDir: '/fake' });
+    const result: IssuesOutput = await creator.createFromTasks('tasks.md', {
+      dryRun: true,
+      labels: ['squad'],
+    });
+
+    expect(result.humanOutput).toContain('[DRY RUN]');
+  });
+
+  it('human output does not contain [DRY RUN] when dryRun=false', async () => {
+    const creator = createIssueCreator({ baseDir: '/fake' });
+    const result: IssuesOutput = await creator.createFromTasks('tasks.md', {
+      dryRun: false,
+      labels: ['squad'],
+      repository: 'test/repo',
+    });
+
+    expect(result.humanOutput).not.toContain('[DRY RUN]');
+  });
+
+  it('JSON output includes dryRun=true', async () => {
+    const creator = createIssueCreator({ baseDir: '/fake' });
+    const result: IssuesOutput = await creator.createFromTasks('tasks.md', {
+      dryRun: true,
+    });
+
+    expect(result.jsonOutput.dryRun).toBe(true);
+  });
+
+  it('JSON output includes dryRun=false', async () => {
+    const creator = createIssueCreator({ baseDir: '/fake' });
+    const result: IssuesOutput = await creator.createFromTasks('tasks.md', {
+      dryRun: false,
+      repository: 'test/repo',
+    });
+
+    expect(result.jsonOutput.dryRun).toBe(false);
+  });
+
+  it('human output indicates no changes were made in dry-run', async () => {
+    const creator = createIssueCreator({ baseDir: '/fake' });
+    const result: IssuesOutput = await creator.createFromTasks('tasks.md', {
+      dryRun: true,
+    });
+
+    expect(result.humanOutput).toContain('No changes were made');
+  });
+
+  it('human output lists would-be-created issues in dry-run', async () => {
+    const creator = createIssueCreator({ baseDir: '/fake' });
+    const result: IssuesOutput = await creator.createFromTasks('tasks.md', {
+      dryRun: true,
+    });
+
+    expect(result.humanOutput).toContain('Would create issues');
+    expect(result.humanOutput).toContain('T001');
+    expect(result.humanOutput).toContain('T002');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────
+// Sync output tests
+// ─────────────────────────────────────────────────────────────
+
+describe('Sync dry-run output formatting', () => {
+  it('human output contains [DRY RUN] prefix when dryRun=true', async () => {
+    const syncer = createSyncer({ baseDir: '/fake' });
+    const result: SyncOutput = await syncer.sync('specs/001', { dryRun: true });
+
+    expect(result.humanOutput).toContain('[DRY RUN]');
+  });
+
+  it('human output indicates no changes were made in dry-run', async () => {
+    const syncer = createSyncer({ baseDir: '/fake' });
+    const result: SyncOutput = await syncer.sync('specs/001', { dryRun: true });
+
+    expect(result.humanOutput).toContain('No changes were made');
+  });
+
+  it('JSON output includes dryRun=true', async () => {
+    const syncer = createSyncer({ baseDir: '/fake' });
+    const result: SyncOutput = await syncer.sync('specs/001', { dryRun: true });
+
+    expect(result.jsonOutput.dryRun).toBe(true);
+  });
+
+  it('JSON output includes dryRun=false', async () => {
+    const syncer = createSyncer({ baseDir: '/fake' });
+    const result: SyncOutput = await syncer.sync('specs/001', { dryRun: false });
+
+    expect(result.jsonOutput.dryRun).toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────
+// Review output tests
+// ─────────────────────────────────────────────────────────────
+
+describe('Review dry-run output formatting', () => {
+  it('human output contains [DRY RUN] prefix when dryRun=true', async () => {
+    const reviewer = createReviewer({ baseDir: '/fake' });
+    const result: ReviewOutput = await reviewer.review('tasks.md', undefined, { dryRun: true });
+
+    expect(result.humanOutput).toContain('[DRY RUN]');
+  });
+
+  it('human output does not contain [DRY RUN] when dryRun=false', async () => {
+    const reviewer = createReviewer({ baseDir: '/fake' });
+    const result: ReviewOutput = await reviewer.review('tasks.md', undefined, { dryRun: false });
+
+    expect(result.humanOutput).not.toContain('[DRY RUN]');
+  });
+
+  it('JSON output includes dryRun=true', async () => {
+    const reviewer = createReviewer({ baseDir: '/fake' });
+    const result: ReviewOutput = await reviewer.review('tasks.md', undefined, { dryRun: true });
+
+    expect(result.jsonOutput.dryRun).toBe(true);
+  });
+
+  it('JSON output includes dryRun=false', async () => {
+    const reviewer = createReviewer({ baseDir: '/fake' });
+    const result: ReviewOutput = await reviewer.review('tasks.md', undefined, { dryRun: false });
+
+    expect(result.jsonOutput.dryRun).toBe(false);
+  });
+
+  it('dry-run review indicates no file was written', async () => {
+    const reviewer = createReviewer({ baseDir: '/fake' });
+    const result: ReviewOutput = await reviewer.review('tasks.md', undefined, { dryRun: true });
+
+    expect(result.humanOutput).toContain('Would write review');
+    expect(result.humanOutput).toContain('No changes were made');
+  });
+
+  it('non-dry-run review indicates file was written', async () => {
+    const reviewer = createReviewer({ baseDir: '/fake' });
+    const result: ReviewOutput = await reviewer.review('tasks.md', undefined, { dryRun: false });
+
+    expect(result.humanOutput).toContain('Review template written to');
+  });
+});

--- a/tests/unit/dry-run.test.ts
+++ b/tests/unit/dry-run.test.ts
@@ -1,0 +1,367 @@
+/**
+ * T018-T022: Dry-Run Feature Chain Tests
+ *
+ * Comprehensive tests covering:
+ *   T018: --dry-run / -n global flag parsing and pipeline propagation
+ *   T019: Issues stage dry-run simulation
+ *   T020: Stage validation / write-skip behavior in dry-run mode
+ *   T021: [DRY RUN] indicator in human output
+ *   T022: dryRun field in JSON output
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { createIssuesFromTasks } from '../../src/issues/create-issues.js';
+import { syncLearnings } from '../../src/sync/sync-learnings.js';
+import type { SyncStateReader } from '../../src/sync/sync-learnings.js';
+import type { IssueCreator, TasksMarkdownReader, SquadMemoryWriter } from '../../src/bridge/ports.js';
+import type { TaskEntry } from '../../src/types.js';
+
+// ─────────────────────────────────────────────────────────────
+// Test helpers
+// ─────────────────────────────────────────────────────────────
+
+function makeTasks(): TaskEntry[] {
+  return [
+    { id: 'T001', title: 'Setup', description: 'Setup — initial', dependencies: [], status: 'pending' },
+    { id: 'T002', title: 'Build', description: 'Build — compile', dependencies: ['T001'], status: 'pending' },
+    { id: 'T003', title: 'Done', description: 'Already done', dependencies: [], status: 'done' },
+  ];
+}
+
+function makeReader(tasks?: TaskEntry[]): TasksMarkdownReader {
+  return {
+    readAndParse: vi.fn().mockResolvedValue(tasks ?? makeTasks()),
+  };
+}
+
+function makeIssueCreator(): IssueCreator & { create: ReturnType<typeof vi.fn> } {
+  let counter = 100;
+  return {
+    create: vi.fn().mockImplementation(async (task: TaskEntry) => ({
+      issueNumber: counter++,
+      title: `${task.id}: ${task.title}`,
+      body: task.description,
+      labels: ['squad'],
+      taskId: task.id,
+      url: `https://github.com/test/repo/issues/${counter - 1}`,
+      createdAt: new Date().toISOString(),
+    })),
+    createBatch: vi.fn().mockResolvedValue([]),
+  };
+}
+
+function makeSyncStateReader(overrides: Partial<SyncStateReader> = {}): SyncStateReader {
+  return {
+    readSyncState: vi.fn().mockResolvedValue(null),
+    writeSyncState: vi.fn().mockResolvedValue(undefined),
+    readSpecResults: vi.fn().mockResolvedValue([
+      { title: 'Learning 1', content: 'Content 1' },
+      { title: 'Learning 2', content: 'Content 2' },
+    ]),
+    ...overrides,
+  };
+}
+
+function makeMemoryWriter(): SquadMemoryWriter & { writeLearning: ReturnType<typeof vi.fn> } {
+  return {
+    writeLearning: vi.fn().mockResolvedValue('.squad/agents/bridge/history.md'),
+    writeDecision: vi.fn().mockResolvedValue('.squad/decisions.md'),
+  };
+}
+
+// ─────────────────────────────────────────────────────────────
+// T018: --dry-run flag option and pipeline propagation
+// ─────────────────────────────────────────────────────────────
+
+describe('T018: --dry-run flag propagation', () => {
+  it('issues use case receives dryRun=true and produces dry-run result', async () => {
+    const reader = makeReader();
+    const creator = makeIssueCreator();
+
+    const result = await createIssuesFromTasks(reader, creator, {
+      tasksFilePath: 'tasks.md',
+      labels: ['squad'],
+      repository: 'test/repo',
+      dryRun: true,
+    });
+
+    expect(result.dryRun).toBe(true);
+  });
+
+  it('issues use case receives dryRun=false and produces non-dry-run result', async () => {
+    const reader = makeReader();
+    const creator = makeIssueCreator();
+
+    const result = await createIssuesFromTasks(reader, creator, {
+      tasksFilePath: 'tasks.md',
+      labels: ['squad'],
+      repository: 'test/repo',
+      dryRun: false,
+    });
+
+    expect(result.dryRun).toBe(false);
+  });
+
+  it('sync use case receives dryRun=true and produces dry-run result', async () => {
+    const stateReader = makeSyncStateReader();
+    const writer = makeMemoryWriter();
+
+    const result = await syncLearnings(stateReader, writer, {
+      specDir: 'specs/001',
+      squadDir: '.squad',
+      dryRun: true,
+    });
+
+    expect(result.dryRun).toBe(true);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────
+// T019: Issues stage dry-run simulation
+// ─────────────────────────────────────────────────────────────
+
+describe('T019: Issues stage dry-run simulation', () => {
+  it('does not call GitHub API (issueCreator.create) in dry-run', async () => {
+    const reader = makeReader();
+    const creator = makeIssueCreator();
+
+    await createIssuesFromTasks(reader, creator, {
+      tasksFilePath: 'tasks.md',
+      labels: ['squad'],
+      repository: 'test/repo',
+      dryRun: true,
+    });
+
+    expect(creator.create).not.toHaveBeenCalled();
+  });
+
+  it('produces placeholder IssueRecords with issueNumber=0 in dry-run', async () => {
+    const reader = makeReader();
+    const creator = makeIssueCreator();
+
+    const result = await createIssuesFromTasks(reader, creator, {
+      tasksFilePath: 'tasks.md',
+      labels: ['squad'],
+      repository: 'test/repo',
+      dryRun: true,
+    });
+
+    expect(result.created).toHaveLength(2);
+    for (const issue of result.created) {
+      expect(issue.issueNumber).toBe(0);
+      expect(issue.url).toBe('');
+    }
+  });
+
+  it('includes correct titles for simulated issues', async () => {
+    const reader = makeReader();
+    const creator = makeIssueCreator();
+
+    const result = await createIssuesFromTasks(reader, creator, {
+      tasksFilePath: 'tasks.md',
+      labels: ['squad', 'v2'],
+      repository: 'test/repo',
+      dryRun: true,
+    });
+
+    expect(result.created[0].title).toContain('T001');
+    expect(result.created[1].title).toContain('T002');
+  });
+
+  it('preserves labels in dry-run placeholders', async () => {
+    const reader = makeReader();
+    const creator = makeIssueCreator();
+
+    const result = await createIssuesFromTasks(reader, creator, {
+      tasksFilePath: 'tasks.md',
+      labels: ['squad', 'dry-run-test'],
+      repository: 'test/repo',
+      dryRun: true,
+    });
+
+    expect(result.created[0].labels).toEqual(['squad', 'dry-run-test']);
+  });
+
+  it('correctly reports total/eligible/skipped counts in dry-run', async () => {
+    const reader = makeReader();
+    const creator = makeIssueCreator();
+
+    const result = await createIssuesFromTasks(reader, creator, {
+      tasksFilePath: 'tasks.md',
+      labels: [],
+      repository: 'test/repo',
+      dryRun: true,
+    });
+
+    expect(result.total).toBe(3);
+    expect(result.created).toHaveLength(2);
+    expect(result.skipped).toHaveLength(1);
+    expect(result.skipped[0].id).toBe('T003');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────
+// T020: Stage validation / write-skip in dry-run
+// ─────────────────────────────────────────────────────────────
+
+describe('T020: Stage write-skip behavior in dry-run', () => {
+  it('sync dry-run does not write learnings to memory', async () => {
+    const stateReader = makeSyncStateReader();
+    const writer = makeMemoryWriter();
+
+    await syncLearnings(stateReader, writer, {
+      specDir: 'specs/001',
+      squadDir: '.squad',
+      dryRun: true,
+    });
+
+    expect(writer.writeLearning).not.toHaveBeenCalled();
+  });
+
+  it('sync dry-run does not update sync state', async () => {
+    const writeSyncState = vi.fn().mockResolvedValue(undefined);
+    const stateReader = makeSyncStateReader({ writeSyncState });
+    const writer = makeMemoryWriter();
+
+    await syncLearnings(stateReader, writer, {
+      specDir: 'specs/001',
+      squadDir: '.squad',
+      dryRun: true,
+    });
+
+    expect(writeSyncState).not.toHaveBeenCalled();
+  });
+
+  it('sync dry-run returns empty filesWritten array', async () => {
+    const stateReader = makeSyncStateReader();
+    const writer = makeMemoryWriter();
+
+    const result = await syncLearnings(stateReader, writer, {
+      specDir: 'specs/001',
+      squadDir: '.squad',
+      dryRun: true,
+    });
+
+    expect(result.record.filesWritten).toHaveLength(0);
+  });
+
+  it('issues dry-run still reads and parses the tasks file', async () => {
+    const reader = makeReader();
+    const creator = makeIssueCreator();
+
+    await createIssuesFromTasks(reader, creator, {
+      tasksFilePath: 'tasks.md',
+      labels: [],
+      repository: 'test/repo',
+      dryRun: true,
+    });
+
+    expect(reader.readAndParse).toHaveBeenCalledWith('tasks.md');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────
+// T021: [DRY RUN] indicator in human output
+// ─────────────────────────────────────────────────────────────
+
+describe('T021: [DRY RUN] indicator in human output', () => {
+  it('sync dry-run summary contains [DRY RUN] prefix', async () => {
+    const stateReader = makeSyncStateReader();
+    const writer = makeMemoryWriter();
+
+    const result = await syncLearnings(stateReader, writer, {
+      specDir: 'specs/001',
+      squadDir: '.squad',
+      dryRun: true,
+    });
+
+    expect(result.record.summary).toContain('[DRY RUN]');
+  });
+
+  it('sync non-dry-run summary does not contain [DRY RUN]', async () => {
+    const stateReader = makeSyncStateReader();
+    const writer = makeMemoryWriter();
+
+    const result = await syncLearnings(stateReader, writer, {
+      specDir: 'specs/001',
+      squadDir: '.squad',
+      dryRun: false,
+    });
+
+    expect(result.record.summary).not.toContain('[DRY RUN]');
+  });
+
+  it('sync dry-run summary describes what would happen', async () => {
+    const stateReader = makeSyncStateReader();
+    const writer = makeMemoryWriter();
+
+    const result = await syncLearnings(stateReader, writer, {
+      specDir: 'specs/001',
+      squadDir: '.squad',
+      dryRun: true,
+    });
+
+    expect(result.record.summary).toContain('Would sync');
+    expect(result.record.summary).toContain('2 learning(s)');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────
+// T022: dryRun field in JSON output
+// ─────────────────────────────────────────────────────────────
+
+describe('T022: dryRun field in result objects', () => {
+  it('issues result includes dryRun=true when dry-run', async () => {
+    const reader = makeReader();
+    const creator = makeIssueCreator();
+
+    const result = await createIssuesFromTasks(reader, creator, {
+      tasksFilePath: 'tasks.md',
+      labels: [],
+      repository: 'test/repo',
+      dryRun: true,
+    });
+
+    expect(result).toHaveProperty('dryRun', true);
+  });
+
+  it('issues result includes dryRun=false when not dry-run', async () => {
+    const reader = makeReader();
+    const creator = makeIssueCreator();
+
+    const result = await createIssuesFromTasks(reader, creator, {
+      tasksFilePath: 'tasks.md',
+      labels: [],
+      repository: 'test/repo',
+      dryRun: false,
+    });
+
+    expect(result).toHaveProperty('dryRun', false);
+  });
+
+  it('sync result includes dryRun=true when dry-run', async () => {
+    const stateReader = makeSyncStateReader();
+    const writer = makeMemoryWriter();
+
+    const result = await syncLearnings(stateReader, writer, {
+      specDir: 'specs/001',
+      squadDir: '.squad',
+      dryRun: true,
+    });
+
+    expect(result).toHaveProperty('dryRun', true);
+  });
+
+  it('sync result includes dryRun=false when not dry-run', async () => {
+    const stateReader = makeSyncStateReader();
+    const writer = makeMemoryWriter();
+
+    const result = await syncLearnings(stateReader, writer, {
+      specDir: 'specs/001',
+      squadDir: '.squad',
+      dryRun: false,
+    });
+
+    expect(result).toHaveProperty('dryRun', false);
+  });
+});


### PR DESCRIPTION
## Summary
Complete `--dry-run` feature across 5 tasks:
- **T018**: Global `-n, --dry-run` flag in CLI
- **T019**: Issues stage simulates creation (placeholder records)
- **T020**: Install/context/review stages skip writes in dry-run
- **T021**: `[DRY RUN]` prefix in all human output
- **T022**: `dryRun: boolean` field in all JSON outputs

**35 new tests, 218 total passing.**

Closes #222, closes #223, closes #224, closes #225, closes #226

---
*Agent: 🔧 Dinesh (T018-T022) • Batch 7*