### PR TITLE
feat(cli): add --keep flag with artifact preservation [T023-T026]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,20 @@
 {
-  "name": "squad-speckit-bridge",
-  "version": "0.1.0",
+  "name": "@jmservera/squad-speckit-bridge",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "squad-speckit-bridge",
-      "version": "0.1.0",
-      "license": "ISC",
+      "name": "@jmservera/squad-speckit-bridge",
+      "version": "0.2.0",
+      "license": "MIT",
       "dependencies": {
         "commander": "^14.0.3",
         "glob": "^13.0.6",
         "gray-matter": "^4.0.3"
       },
       "bin": {
+        "sqsk": "dist/cli/index.js",
         "squad-speckit-bridge": "dist/cli/index.js"
       },
       "devDependencies": {
@@ -21,6 +22,9 @@
         "tsx": "^4.21.0",
         "typescript": "^5.9.3",
         "vitest": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@emnapi/core": {
@@ -844,7 +848,6 @@
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -1611,7 +1614,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1809,7 +1811,6 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -1851,7 +1852,6 @@
       "integrity": "sha512-wt+Z2qIhfFt85uiyRt5LPU4oVEJBXj8hZNWKeqFG4gRG/0RaRGJ7njQCwzFVjO+v4+Ipmf5CY7VdmZRAYYBPHw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.3",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -343,7 +343,7 @@ program
   .command('demo')
   .description('Run E2E demo of the pipeline')
   .option('--dry-run', 'Simulate GitHub issue creation without API calls', false)
-  .option('--keep', 'Preserve demo artifacts after completion', false)
+  .option('-k, --keep', 'Preserve demo artifacts after completion', false)
   .option('--verbose', 'Enable verbose output', false)
   .option('--json', 'Output in JSON format', false)
   .action(async (cmdOpts: Record<string, unknown>) => {

--- a/src/demo/adapters/cleanup-handler.ts
+++ b/src/demo/adapters/cleanup-handler.ts
@@ -48,6 +48,8 @@ export class FileSystemCleanupHandler implements CleanupHandler {
       return {
         ...report,
         cleanupPerformed: false,
+        kept: true,
+        artifactPaths: [config.demoDir, ...report.artifacts.map((a) => a.path)],
       };
     }
 

--- a/src/demo/entities.ts
+++ b/src/demo/entities.ts
@@ -144,6 +144,10 @@ export interface ExecutionReport {
   artifacts: ArtifactSummary[];
   /** True if demo directory was deleted */
   cleanupPerformed: boolean;
+  /** True if --keep flag was active and artifacts were preserved */
+  kept: boolean;
+  /** Paths to preserved artifacts when --keep is active */
+  artifactPaths: string[];
   /** High-level error description if demo failed */
   errorSummary?: string;
 }

--- a/src/demo/formatters.ts
+++ b/src/demo/formatters.ts
@@ -102,6 +102,14 @@ export function formatHumanOutput(report: ExecutionReport): string {
   lines.push('');
   if (report.cleanupPerformed) {
     lines.push(`  ${EMOJI.SUCCESS} Demo directory cleaned up`);
+  } else if (report.kept) {
+    lines.push(`  📦 Artifacts preserved (--keep)`);
+    if (report.artifactPaths.length > 0) {
+      lines.push(`     Location: ${report.artifactPaths[0]}`);
+      for (const artifactPath of report.artifactPaths.slice(1)) {
+        lines.push(`       • ${artifactPath}`);
+      }
+    }
   } else {
     lines.push(`  ${EMOJI.RUNNING} Demo artifacts preserved`);
   }
@@ -172,6 +180,8 @@ interface JsonOutputBase {
   stages: JsonStage[];
   demoDir: string;
   cleanupPerformed: boolean;
+  kept: boolean;
+  artifactPaths: string[];
   flags: DemoFlags;
 }
 
@@ -279,6 +289,8 @@ export function formatJsonOutput(report: ExtendedExecutionReport): string {
         stages,
         demoDir: report.demoDir,
         cleanupPerformed: report.cleanupPerformed,
+        kept: report.kept,
+        artifactPaths: report.artifactPaths,
         flags: report.flags,
       }
     : {
@@ -290,6 +302,8 @@ export function formatJsonOutput(report: ExtendedExecutionReport): string {
         errorSummary: report.errorSummary ?? 'Demo failed',
         demoDir: report.demoDir,
         cleanupPerformed: report.cleanupPerformed,
+        kept: report.kept,
+        artifactPaths: report.artifactPaths,
         flags: report.flags,
       };
 

--- a/src/demo/orchestrator.ts
+++ b/src/demo/orchestrator.ts
@@ -206,17 +206,28 @@ export async function runDemo(
     stagesFailed,
     artifacts,
     cleanupPerformed: false,
+    kept: false,
+    artifactPaths: [],
     errorSummary,
   };
 
   // Automatic cleanup logic:
+  // - If keep=true: skip cleanup, mark artifacts as kept
   // - If keep=false AND all stages succeeded: perform cleanup
-  // - If keep=true OR any stage failed: skip cleanup (preserve artifacts for debugging)
+  // - If keep=false AND any stage failed: skip cleanup (preserve artifacts for debugging)
   const allStagesSucceeded = stagesFailed === 0;
-  if (!config.flags.keep && allStagesSucceeded) {
+  if (config.flags.keep) {
+    // --keep flag active: preserve artifacts and record their paths
+    const preservedPaths = artifacts.map((a) => a.path);
+    if (config.demoDir) {
+      preservedPaths.unshift(config.demoDir);
+    }
+    report.kept = true;
+    report.artifactPaths = preservedPaths;
+  } else if (allStagesSucceeded) {
     report = await deps.cleanupHandler.cleanup(config, report);
   }
-  // Otherwise, cleanupPerformed remains false (artifacts preserved)
+  // Otherwise, cleanupPerformed remains false (artifacts preserved for debugging)
 
   return report;
 }

--- a/tests/unit/keep-flag.test.ts
+++ b/tests/unit/keep-flag.test.ts
@@ -1,0 +1,441 @@
+/**
+ * T023-T026: --keep flag feature tests
+ *
+ * Tests for the complete --keep flag chain:
+ * - T023: CLI argument parsing with -k/--keep
+ * - T024: Cleanup logic respects --keep
+ * - T025: Artifact preservation messages
+ * - T026: JSON output includes kept/artifactPaths
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { runDemo, createPipelineStages, createDemoDirectory } from '../../src/demo/orchestrator.js';
+import { formatHumanOutput, formatJsonOutput, type ExtendedExecutionReport } from '../../src/demo/formatters.js';
+import { FileSystemCleanupHandler } from '../../src/demo/adapters/cleanup-handler.js';
+import { StageStatus } from '../../src/demo/entities.js';
+import type { DemoConfiguration, ExecutionReport, PipelineStage } from '../../src/demo/entities.js';
+import type { DemoDependencies } from '../../src/demo/orchestrator.js';
+
+// ─────────────────────────────────────────────────────────────
+// Test Helpers
+// ─────────────────────────────────────────────────────────────
+
+function makeConfig(overrides: Partial<DemoConfiguration> = {}): DemoConfiguration {
+  return {
+    exampleFeature: 'Test Feature',
+    demoDir: 'specs/demo-20250101-120000',
+    flags: {
+      dryRun: false,
+      keep: false,
+      verbose: false,
+    },
+    timeout: 30,
+    squadDir: '.squad',
+    specifyDir: 'specs',
+    ...overrides,
+  };
+}
+
+function makeKeepConfig(overrides: Partial<DemoConfiguration> = {}): DemoConfiguration {
+  return makeConfig({
+    flags: { dryRun: false, keep: true, verbose: false },
+    ...overrides,
+  });
+}
+
+function makeSuccessResult() {
+  return {
+    success: true,
+    exitCode: 0,
+    stdout: 'stage output',
+    stderr: '',
+    timedOut: false,
+  };
+}
+
+function makeValidArtifact(path: string) {
+  return {
+    path,
+    type: 'spec' as const,
+    sizeBytes: 2048,
+    exists: true,
+    valid: true,
+    errors: [],
+  };
+}
+
+function makeDeps(overrides: Partial<DemoDependencies> = {}): DemoDependencies {
+  return {
+    processExecutor: {
+      execute: vi.fn(),
+      run: vi.fn().mockResolvedValue(makeSuccessResult()),
+      isCommandAvailable: vi.fn().mockResolvedValue(true),
+    },
+    artifactValidator: {
+      validate: vi.fn().mockImplementation(async (artifactPath: string) =>
+        makeValidArtifact(artifactPath),
+      ),
+      validateAll: vi.fn().mockResolvedValue([]),
+    },
+    cleanupHandler: {
+      cleanup: vi.fn().mockImplementation(async (_config: DemoConfiguration, report: ExecutionReport) => ({
+        ...report,
+        cleanupPerformed: true,
+      })),
+      isSafeToDelete: vi.fn().mockResolvedValue(true),
+    },
+    ...overrides,
+  };
+}
+
+function makeReport(overrides: Partial<ExecutionReport> = {}): ExecutionReport {
+  return {
+    totalTimeMs: 5000,
+    stagesCompleted: 5,
+    stagesFailed: 0,
+    artifacts: [
+      { name: 'spec.md', path: 'specs/demo-20250101-120000/spec.md', sizeKB: '2.0 KB' },
+      { name: 'plan.md', path: 'specs/demo-20250101-120000/plan.md', sizeKB: '1.5 KB' },
+    ],
+    cleanupPerformed: false,
+    kept: false,
+    artifactPaths: [],
+    ...overrides,
+  };
+}
+
+function makeExtendedReport(overrides: Partial<ExtendedExecutionReport> = {}): ExtendedExecutionReport {
+  const stages: PipelineStage[] = [
+    { name: 'specify', displayName: 'Generating specification', command: ['speckit', 'specify'], artifact: 'spec.md', status: StageStatus.Success, elapsedMs: 1000 },
+    { name: 'plan', displayName: 'Creating implementation plan', command: ['speckit', 'plan'], artifact: 'plan.md', status: StageStatus.Success, elapsedMs: 800 },
+  ];
+  return {
+    ...makeReport(),
+    stages,
+    demoDir: 'specs/demo-20250101-120000',
+    flags: { dryRun: false, keep: false, verbose: false },
+    ...overrides,
+  };
+}
+
+// ─────────────────────────────────────────────────────────────
+// T023: --keep flag parsing and pipeline pass-through
+// ─────────────────────────────────────────────────────────────
+
+describe('T023: --keep flag option', () => {
+  it('config.flags.keep defaults to false', () => {
+    const config = makeConfig();
+    expect(config.flags.keep).toBe(false);
+  });
+
+  it('config.flags.keep can be set to true', () => {
+    const config = makeKeepConfig();
+    expect(config.flags.keep).toBe(true);
+  });
+
+  it('keep flag is passed through to orchestrator', async () => {
+    const deps = makeDeps();
+    const config = makeKeepConfig();
+
+    const report = await runDemo(config, deps);
+    // When keep=true, cleanup should not be called
+    expect(deps.cleanupHandler.cleanup).not.toHaveBeenCalled();
+    expect(report.kept).toBe(true);
+  });
+
+  it('keep flag false allows cleanup to proceed', async () => {
+    const deps = makeDeps();
+    const config = makeConfig();
+
+    await runDemo(config, deps);
+    expect(deps.cleanupHandler.cleanup).toHaveBeenCalledOnce();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────
+// T024: Cleanup logic respects --keep
+// ─────────────────────────────────────────────────────────────
+
+describe('T024: cleanup logic for --keep flag', () => {
+  it('skips cleanup entirely when --keep is active', async () => {
+    const deps = makeDeps();
+    const config = makeKeepConfig();
+
+    const report = await runDemo(config, deps);
+
+    expect(report.cleanupPerformed).toBe(false);
+    expect(report.kept).toBe(true);
+    expect(deps.cleanupHandler.cleanup).not.toHaveBeenCalled();
+  });
+
+  it('performs cleanup when --keep is not active and all stages succeed', async () => {
+    const deps = makeDeps();
+    const config = makeConfig();
+
+    const report = await runDemo(config, deps);
+
+    expect(deps.cleanupHandler.cleanup).toHaveBeenCalledOnce();
+    expect(report.cleanupPerformed).toBe(true);
+  });
+
+  it('skips cleanup on failure even without --keep (for debugging)', async () => {
+    const deps = makeDeps({
+      processExecutor: {
+        execute: vi.fn(),
+        run: vi.fn().mockResolvedValue({
+          success: false,
+          exitCode: 1,
+          stdout: '',
+          stderr: 'command failed',
+          timedOut: false,
+        }),
+        isCommandAvailable: vi.fn().mockResolvedValue(true),
+      },
+    });
+    const config = makeConfig();
+
+    const report = await runDemo(config, deps);
+
+    expect(report.cleanupPerformed).toBe(false);
+    expect(report.kept).toBe(false);
+    expect(deps.cleanupHandler.cleanup).not.toHaveBeenCalled();
+  });
+
+  it('cleanup handler respects keep flag internally', async () => {
+    const handler = new FileSystemCleanupHandler();
+    const config = makeKeepConfig();
+    const report = makeReport();
+
+    const result = await handler.cleanup(config, report);
+
+    expect(result.cleanupPerformed).toBe(false);
+    expect(result.kept).toBe(true);
+    expect(result.artifactPaths).toContain(config.demoDir);
+  });
+
+  it('cleanup handler includes artifact paths when keep is true', async () => {
+    const handler = new FileSystemCleanupHandler();
+    const config = makeKeepConfig();
+    const report = makeReport({
+      artifacts: [
+        { name: 'spec.md', path: 'specs/demo-20250101-120000/spec.md', sizeKB: '2.0 KB' },
+        { name: 'plan.md', path: 'specs/demo-20250101-120000/plan.md', sizeKB: '1.5 KB' },
+      ],
+    });
+
+    const result = await handler.cleanup(config, report);
+
+    expect(result.artifactPaths).toContain('specs/demo-20250101-120000');
+    expect(result.artifactPaths).toContain('specs/demo-20250101-120000/spec.md');
+    expect(result.artifactPaths).toContain('specs/demo-20250101-120000/plan.md');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────
+// T025: Artifact preservation message
+// ─────────────────────────────────────────────────────────────
+
+describe('T025: artifact preservation message', () => {
+  it('shows preservation message with location when --keep is active', () => {
+    const report = makeReport({
+      kept: true,
+      artifactPaths: [
+        'specs/demo-20250101-120000',
+        'specs/demo-20250101-120000/spec.md',
+        'specs/demo-20250101-120000/plan.md',
+      ],
+    });
+
+    const output = formatHumanOutput(report);
+
+    expect(output).toContain('Artifacts preserved (--keep)');
+    expect(output).toContain('specs/demo-20250101-120000');
+  });
+
+  it('lists individual artifact paths in preservation message', () => {
+    const report = makeReport({
+      kept: true,
+      artifactPaths: [
+        'specs/demo-20250101-120000',
+        'specs/demo-20250101-120000/spec.md',
+        'specs/demo-20250101-120000/plan.md',
+      ],
+    });
+
+    const output = formatHumanOutput(report);
+
+    expect(output).toContain('spec.md');
+    expect(output).toContain('plan.md');
+  });
+
+  it('shows standard cleanup message when not kept', () => {
+    const report = makeReport({ cleanupPerformed: true });
+
+    const output = formatHumanOutput(report);
+
+    expect(output).toContain('Demo directory cleaned up');
+    expect(output).not.toContain('Artifacts preserved (--keep)');
+  });
+
+  it('shows generic preserved message when cleanup skipped without --keep', () => {
+    const report = makeReport({ cleanupPerformed: false, kept: false });
+
+    const output = formatHumanOutput(report);
+
+    expect(output).toContain('Demo artifacts preserved');
+    expect(output).not.toContain('--keep');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────
+// T026: JSON output includes kept and artifactPaths
+// ─────────────────────────────────────────────────────────────
+
+describe('T026: JSON output with kept and artifactPaths', () => {
+  it('includes kept: true in JSON when --keep is active', () => {
+    const report = makeExtendedReport({
+      kept: true,
+      artifactPaths: ['specs/demo-20250101-120000'],
+      flags: { dryRun: false, keep: true, verbose: false },
+    });
+
+    const json = JSON.parse(formatJsonOutput(report));
+
+    expect(json.kept).toBe(true);
+  });
+
+  it('includes kept: false in JSON when --keep is not active', () => {
+    const report = makeExtendedReport({
+      cleanupPerformed: true,
+      kept: false,
+      artifactPaths: [],
+    });
+
+    const json = JSON.parse(formatJsonOutput(report));
+
+    expect(json.kept).toBe(false);
+  });
+
+  it('includes artifactPaths array in JSON output', () => {
+    const paths = [
+      'specs/demo-20250101-120000',
+      'specs/demo-20250101-120000/spec.md',
+      'specs/demo-20250101-120000/plan.md',
+    ];
+    const report = makeExtendedReport({
+      kept: true,
+      artifactPaths: paths,
+      flags: { dryRun: false, keep: true, verbose: false },
+    });
+
+    const json = JSON.parse(formatJsonOutput(report));
+
+    expect(json.artifactPaths).toEqual(paths);
+  });
+
+  it('artifactPaths is empty array when not kept', () => {
+    const report = makeExtendedReport({
+      cleanupPerformed: true,
+      kept: false,
+      artifactPaths: [],
+    });
+
+    const json = JSON.parse(formatJsonOutput(report));
+
+    expect(json.artifactPaths).toEqual([]);
+  });
+
+  it('JSON output includes both kept and cleanupPerformed', () => {
+    const report = makeExtendedReport({
+      kept: true,
+      cleanupPerformed: false,
+      artifactPaths: ['specs/demo-20250101-120000'],
+      flags: { dryRun: false, keep: true, verbose: false },
+    });
+
+    const json = JSON.parse(formatJsonOutput(report));
+
+    expect(json.kept).toBe(true);
+    expect(json.cleanupPerformed).toBe(false);
+  });
+
+  it('JSON output preserves flags.keep field', () => {
+    const report = makeExtendedReport({
+      kept: true,
+      artifactPaths: ['specs/demo-20250101-120000'],
+      flags: { dryRun: false, keep: true, verbose: false },
+    });
+
+    const json = JSON.parse(formatJsonOutput(report));
+
+    expect(json.flags.keep).toBe(true);
+  });
+
+  it('JSON failure output includes kept and artifactPaths', () => {
+    const failedStage: PipelineStage = {
+      name: 'specify',
+      displayName: 'Generating specification',
+      command: ['speckit', 'specify'],
+      artifact: 'spec.md',
+      status: StageStatus.Failed,
+      elapsedMs: 500,
+      error: 'Command failed',
+    };
+    const report = makeExtendedReport({
+      stagesFailed: 1,
+      stagesCompleted: 0,
+      stages: [failedStage],
+      kept: false,
+      artifactPaths: [],
+      errorSummary: 'Stage specify failed',
+    });
+
+    const json = JSON.parse(formatJsonOutput(report));
+
+    expect(json.success).toBe(false);
+    expect(json.kept).toBe(false);
+    expect(json.artifactPaths).toEqual([]);
+    expect(json.failedStage).toBe('specify');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────
+// Integration: Orchestrator end-to-end with --keep
+// ─────────────────────────────────────────────────────────────
+
+describe('Orchestrator --keep integration', () => {
+  it('produces complete report with artifact paths when --keep is active', async () => {
+    const deps = makeDeps();
+    const config = makeKeepConfig();
+
+    const report = await runDemo(config, deps);
+
+    expect(report.kept).toBe(true);
+    expect(report.cleanupPerformed).toBe(false);
+    expect(report.artifactPaths.length).toBeGreaterThan(0);
+    expect(report.artifactPaths[0]).toBe(config.demoDir);
+  });
+
+  it('produces complete report without artifact paths when not kept', async () => {
+    const deps = makeDeps();
+    const config = makeConfig();
+
+    const report = await runDemo(config, deps);
+
+    expect(report.kept).toBe(false);
+    expect(report.cleanupPerformed).toBe(true);
+    expect(report.artifactPaths).toEqual([]);
+  });
+
+  it('createDemoDirectory generates unique paths under specs/', () => {
+    const dir = createDemoDirectory();
+    expect(dir).toMatch(/^specs\/demo-\d{8}-\d{6}$/);
+  });
+
+  it('createPipelineStages includes --dry-run for issues when dryRun=true', () => {
+    const config = makeKeepConfig({ flags: { dryRun: true, keep: true, verbose: false } });
+    const stages = createPipelineStages(config);
+    const issuesStage = stages.find(s => s.name === 'issues');
+    expect(issuesStage?.command).toContain('--dry-run');
+  });
+});


### PR DESCRIPTION
## Summary
Complete `--keep` feature across 4 tasks:
- **T023**: `-k, --keep` flag in CLI
- **T024**: Orchestrator skips cleanup, sets kept/artifactPaths on report
- **T025**: `📦 Artifacts preserved` message with directory + file paths
- **T026**: `kept: boolean` and `artifactPaths: string[]` in JSON output

**24 new tests, 207 total passing.**

Closes #227, closes #228, closes #229, closes #230

---
*Agent: 🔧 Dinesh (T023-T026) • Batch 8*