### PR TITLE
fix(hooks): fix template permissions, command name, and automation

### DIFF
--- a/src/install/templates/hooks/after-implement.sh
+++ b/src/install/templates/hooks/after-implement.sh
@@ -5,13 +5,6 @@
 
 set -euo pipefail
 
-# Check npx availability
-if ! command -v npx &> /dev/null; then
-  echo "[squad-bridge] WARNING: npx not found — skipping learning sync."
-  echo "[squad-bridge] Install Node.js 18+ to enable the Squad-SpecKit bridge."
-  exit 0
-fi
-
 # Spec Kit sets SPECKIT_SPEC_DIR to the active spec directory
 SPEC_DIR="${SPECKIT_SPEC_DIR:-}"
 
@@ -36,10 +29,15 @@ fi
 
 # Sync learnings from implementation back to Squad memory
 echo "[squad-bridge] Syncing implementation results to Squad memory..."
-npx squad-speckit-bridge sync "$SPEC_DIR" --quiet 2>/dev/null || {
-  echo "[squad-bridge] WARNING: Learning sync failed — manual sync recommended."
-  echo "[squad-bridge] Run: npx squad-speckit-bridge sync ${SPEC_DIR}"
+if command -v squask &> /dev/null; then
+  squask sync "$SPEC_DIR" --quiet 2>/dev/null || {
+    echo "[squad-bridge] WARNING: Learning sync failed — manual sync recommended."
+    echo "[squad-bridge] Run: squask sync ${SPEC_DIR}"
+    exit 0
+  }
+  echo "[squad-bridge] Implementation learnings synced to Squad memory."
+else
+  echo "[squad-bridge] WARNING: squask not found — install squad-speckit-bridge to enable learning sync."
+  echo "[squad-bridge] Install with: npm install -g @jmservera/squad-speckit-bridge"
   exit 0
-}
-
-echo "[squad-bridge] Implementation learnings synced to Squad memory."
+fi

--- a/src/install/templates/hooks/after-tasks.sh
+++ b/src/install/templates/hooks/after-tasks.sh
@@ -1,16 +1,9 @@
 #!/usr/bin/env bash
 # Squad-SpecKit Bridge — after_tasks hook
 # Called by Spec Kit after task generation (speckit.tasks).
-# Notifies the developer that a Design Review is available.
+# Automatically creates GitHub issues from tasks.md.
 
 set -euo pipefail
-
-# Check npx availability
-if ! command -v npx &> /dev/null; then
-  echo "[squad-bridge] WARNING: npx not found — skipping Design Review notification."
-  echo "[squad-bridge] Install Node.js 18+ to enable the Squad-SpecKit bridge."
-  exit 0
-fi
 
 # Spec Kit sets SPECKIT_SPEC_DIR to the active spec directory
 SPEC_DIR="${SPECKIT_SPEC_DIR:-}"
@@ -32,7 +25,7 @@ fi
 
 # Validate tasks file exists
 if [ -z "$TASKS_FILE" ] || [ ! -f "$TASKS_FILE" ]; then
-  echo "[squad-bridge] No tasks.md found — skipping Design Review notification."
+  echo "[squad-bridge] No tasks.md found — skipping issue creation."
   exit 0
 fi
 
@@ -40,8 +33,25 @@ fi
 CONTEXT_FILE="${SPEC_DIR}/squad-context.md"
 if [ ! -f "$CONTEXT_FILE" ]; then
   echo "[squad-bridge] Generating squad-context.md..."
-  npx @jmservera/squad-speckit-bridge context "$SPEC_DIR" --quiet 2>/dev/null || true
+  if command -v squask &> /dev/null; then
+    squask context "$SPEC_DIR" --quiet 2>/dev/null || true
+  else
+    echo "[squad-bridge] WARNING: squask not found — install squad-speckit-bridge to enable context generation."
+  fi
 fi
 
-# Notify developer about available Design Review
-npx @jmservera/squad-speckit-bridge review --notify "$TASKS_FILE"
+# Create GitHub issues from tasks.md
+if command -v squask &> /dev/null; then
+  echo "[squad-bridge] Creating GitHub issues from tasks.md..."
+  squask issues "$TASKS_FILE" || {
+    echo "[squad-bridge] WARNING: Issue creation failed."
+    echo "[squad-bridge] Run manually: squask issues ${TASKS_FILE}"
+    exit 0
+  }
+  echo "[squad-bridge] GitHub issues created successfully."
+else
+  echo "[squad-bridge] WARNING: squask not found — skipping issue creation."
+  echo "[squad-bridge] Install squad-speckit-bridge globally: npm install -g @jmservera/squad-speckit-bridge"
+  echo "[squad-bridge] Then run: squask issues ${TASKS_FILE}"
+  exit 0
+fi

--- a/src/install/templates/hooks/before-specify.sh
+++ b/src/install/templates/hooks/before-specify.sh
@@ -5,13 +5,6 @@
 
 set -euo pipefail
 
-# Check npx availability
-if ! command -v npx &> /dev/null; then
-  echo "[squad-bridge] WARNING: npx not found — skipping context injection."
-  echo "[squad-bridge] Install Node.js 18+ to enable the Squad-SpecKit bridge."
-  exit 0
-fi
-
 # Spec Kit sets SPECKIT_SPEC_DIR to the active spec directory
 SPEC_DIR="${SPECKIT_SPEC_DIR:-}"
 
@@ -36,9 +29,14 @@ fi
 
 # Generate squad-context.md for the spec directory
 echo "[squad-bridge] Injecting Squad context into ${SPEC_DIR}..."
-npx squad-speckit-bridge context "$SPEC_DIR" --quiet 2>/dev/null || {
-  echo "[squad-bridge] WARNING: Context injection failed — continuing without Squad context."
+if command -v squask &> /dev/null; then
+  squask context "$SPEC_DIR" --quiet 2>/dev/null || {
+    echo "[squad-bridge] WARNING: Context injection failed — continuing without Squad context."
+    exit 0
+  }
+  echo "[squad-bridge] Squad context injected successfully."
+else
+  echo "[squad-bridge] WARNING: squask not found — install squad-speckit-bridge to enable context injection."
+  echo "[squad-bridge] Install with: npm install -g @jmservera/squad-speckit-bridge"
   exit 0
-}
-
-echo "[squad-bridge] Squad context injected successfully."
+fi


### PR DESCRIPTION
Fixes #311, #312, #313

## Summary

Fixed three related hook template bugs found during v0.3.0 pipeline retrospective:

1. **Hook templates had wrong permissions (644 instead of 755)** — Fixed by chmod 755 on all source templates
2. **Command name inconsistency (scoped vs unscoped)** — Replaced all `@jmservera/squad-speckit-bridge` references with `squask` binary alias  
3. **after-tasks.sh only notified, didn't create issues** — Now automatically invokes `squask issues` with appropriate error handling and fallback

## Technical Details

- Source templates now executable: `-rwxr-xr-x`
- Dist templates preserve permissions via `cp -r` in build
- All hooks check for `squask` on PATH before invoking
- Graceful degradation with helpful error messages when `squask` not found
- after-tasks.sh auto-creates GitHub issues from tasks.md

## Testing

- ✅ All 818 tests pass
- ✅ Build succeeds
- ✅ Verified dist permissions match source