### PR TITLE
fix(hooks): address review feedback on config check and error handling

### DIFF
--- a/.specify/extensions/squad-bridge/hooks/after-implement.sh
+++ b/.specify/extensions/squad-bridge/hooks/after-implement.sh
@@ -23,12 +23,17 @@ fi
 # Check if the bridge is configured to run after-implement hooks
 CONFIG_FILE="${BRIDGE_CONFIG:-bridge.config.json}"
 if [ -f "$CONFIG_FILE" ]; then
-  HOOK_ENABLED=$(node -e "
-    try {
-      const c = JSON.parse(require('fs').readFileSync('$CONFIG_FILE','utf-8'));
-      console.log(c.hooks?.afterImplement !== false ? 'true' : 'false');
-    } catch { console.log('true'); }
-  " 2>/dev/null || echo "true")
+  if command -v node &> /dev/null; then
+    HOOK_ENABLED=$(node -e "
+      try {
+        const c = JSON.parse(require('fs').readFileSync('$CONFIG_FILE','utf-8'));
+        console.log(c.hooks?.afterImplement !== false ? 'true' : 'false');
+      } catch { console.log('true'); }
+    " 2>/dev/null || echo "true")
+  else
+    echo "[squad-bridge] WARNING: Node.js not found — cannot parse config, defaulting to hook enabled."
+    HOOK_ENABLED="true"
+  fi
   if [ "$HOOK_ENABLED" = "false" ]; then
     exit 0
   fi
@@ -39,7 +44,7 @@ echo "[squad-bridge] Syncing implementation results to Squad memory..."
 npx squad-speckit-bridge sync "$SPEC_DIR" --quiet 2>/dev/null || {
   echo "[squad-bridge] WARNING: Learning sync failed — manual sync recommended."
   echo "[squad-bridge] Run: npx squad-speckit-bridge sync ${SPEC_DIR}"
-  exit 0
+  exit 1
 }
 
 echo "[squad-bridge] Implementation learnings synced to Squad memory."

--- a/.specify/extensions/squad-bridge/hooks/after-tasks.sh
+++ b/.specify/extensions/squad-bridge/hooks/after-tasks.sh
@@ -19,12 +19,17 @@ TASKS_FILE="${SPEC_DIR:+${SPEC_DIR}/tasks.md}"
 # Check if the bridge is configured to run after-tasks hooks
 CONFIG_FILE="${BRIDGE_CONFIG:-bridge.config.json}"
 if [ -f "$CONFIG_FILE" ]; then
-  HOOK_ENABLED=$(node -e "
-    try {
-      const c = JSON.parse(require('fs').readFileSync('$CONFIG_FILE','utf-8'));
-      console.log(c.hooks?.afterTasks !== false ? 'true' : 'false');
-    } catch { console.log('true'); }
-  " 2>/dev/null || echo "true")
+  if command -v node &> /dev/null; then
+    HOOK_ENABLED=$(node -e "
+      try {
+        const c = JSON.parse(require('fs').readFileSync('$CONFIG_FILE','utf-8'));
+        console.log(c.hooks?.afterTasks !== false ? 'true' : 'false');
+      } catch { console.log('true'); }
+    " 2>/dev/null || echo "true")
+  else
+    echo "[squad-bridge] WARNING: Node.js not found — cannot parse config, defaulting to hook enabled."
+    HOOK_ENABLED="true"
+  fi
   if [ "$HOOK_ENABLED" = "false" ]; then
     exit 0
   fi

--- a/.specify/extensions/squad-bridge/hooks/before-specify.sh
+++ b/.specify/extensions/squad-bridge/hooks/before-specify.sh
@@ -23,12 +23,17 @@ fi
 # Check if the bridge is configured to run before-specify hooks
 CONFIG_FILE="${BRIDGE_CONFIG:-bridge.config.json}"
 if [ -f "$CONFIG_FILE" ]; then
-  HOOK_ENABLED=$(node -e "
-    try {
-      const c = JSON.parse(require('fs').readFileSync('$CONFIG_FILE','utf-8'));
-      console.log(c.hooks?.beforeSpecify !== false ? 'true' : 'false');
-    } catch { console.log('true'); }
-  " 2>/dev/null || echo "true")
+  if command -v node &> /dev/null; then
+    HOOK_ENABLED=$(node -e "
+      try {
+        const c = JSON.parse(require('fs').readFileSync('$CONFIG_FILE','utf-8'));
+        console.log(c.hooks?.beforeSpecify !== false ? 'true' : 'false');
+      } catch { console.log('true'); }
+    " 2>/dev/null || echo "true")
+  else
+    echo "[squad-bridge] WARNING: Node.js not found — cannot parse config, defaulting to hook enabled."
+    HOOK_ENABLED="true"
+  fi
   if [ "$HOOK_ENABLED" = "false" ]; then
     exit 0
   fi
@@ -38,7 +43,7 @@ fi
 echo "[squad-bridge] Injecting Squad context into ${SPEC_DIR}..."
 npx squad-speckit-bridge context "$SPEC_DIR" --quiet 2>/dev/null || {
   echo "[squad-bridge] WARNING: Context injection failed — continuing without Squad context."
-  exit 0
+  exit 1
 }
 
 echo "[squad-bridge] Squad context injected successfully."

--- a/src/install/templates/hooks/after-implement.sh
+++ b/src/install/templates/hooks/after-implement.sh
@@ -16,12 +16,17 @@ fi
 # Check if the bridge is configured to run after-implement hooks
 CONFIG_FILE="${BRIDGE_CONFIG:-bridge.config.json}"
 if [ -f "$CONFIG_FILE" ]; then
-  HOOK_ENABLED=$(node -e "
-    try {
-      const c = JSON.parse(require('fs').readFileSync('$CONFIG_FILE','utf-8'));
-      console.log(c.hooks?.afterImplement !== false ? 'true' : 'false');
-    } catch { console.log('true'); }
-  " 2>/dev/null || echo "true")
+  if command -v node &> /dev/null; then
+    HOOK_ENABLED=$(node -e "
+      try {
+        const c = JSON.parse(require('fs').readFileSync('$CONFIG_FILE','utf-8'));
+        console.log(c.hooks?.afterImplement !== false ? 'true' : 'false');
+      } catch { console.log('true'); }
+    " 2>/dev/null || echo "true")
+  else
+    echo "[squad-bridge] WARNING: Node.js not found — cannot parse config, defaulting to hook enabled."
+    HOOK_ENABLED="true"
+  fi
   if [ "$HOOK_ENABLED" = "false" ]; then
     exit 0
   fi
@@ -33,7 +38,7 @@ if command -v squask &> /dev/null; then
   squask sync "$SPEC_DIR" --quiet 2>/dev/null || {
     echo "[squad-bridge] WARNING: Learning sync failed — manual sync recommended."
     echo "[squad-bridge] Run: squask sync ${SPEC_DIR}"
-    exit 0
+    exit 1
   }
   echo "[squad-bridge] Implementation learnings synced to Squad memory."
 else

--- a/src/install/templates/hooks/after-tasks.sh
+++ b/src/install/templates/hooks/after-tasks.sh
@@ -12,12 +12,17 @@ TASKS_FILE="${SPEC_DIR:+${SPEC_DIR}/tasks.md}"
 # Check if the bridge is configured to run after-tasks hooks
 CONFIG_FILE="${BRIDGE_CONFIG:-bridge.config.json}"
 if [ -f "$CONFIG_FILE" ]; then
-  HOOK_ENABLED=$(node -e "
-    try {
-      const c = JSON.parse(require('fs').readFileSync('$CONFIG_FILE','utf-8'));
-      console.log(c.hooks?.afterTasks !== false ? 'true' : 'false');
-    } catch { console.log('true'); }
-  " 2>/dev/null || echo "true")
+  if command -v node &> /dev/null; then
+    HOOK_ENABLED=$(node -e "
+      try {
+        const c = JSON.parse(require('fs').readFileSync('$CONFIG_FILE','utf-8'));
+        console.log(c.hooks?.afterTasks !== false ? 'true' : 'false');
+      } catch { console.log('true'); }
+    " 2>/dev/null || echo "true")
+  else
+    echo "[squad-bridge] WARNING: Node.js not found — cannot parse config, defaulting to hook enabled."
+    HOOK_ENABLED="true"
+  fi
   if [ "$HOOK_ENABLED" = "false" ]; then
     exit 0
   fi
@@ -46,7 +51,7 @@ if command -v squask &> /dev/null; then
   squask issues "$TASKS_FILE" || {
     echo "[squad-bridge] WARNING: Issue creation failed."
     echo "[squad-bridge] Run manually: squask issues ${TASKS_FILE}"
-    exit 0
+    exit 1
   }
   echo "[squad-bridge] GitHub issues created successfully."
 else

--- a/src/install/templates/hooks/before-specify.sh
+++ b/src/install/templates/hooks/before-specify.sh
@@ -16,12 +16,17 @@ fi
 # Check if the bridge is configured to run before-specify hooks
 CONFIG_FILE="${BRIDGE_CONFIG:-bridge.config.json}"
 if [ -f "$CONFIG_FILE" ]; then
-  HOOK_ENABLED=$(node -e "
-    try {
-      const c = JSON.parse(require('fs').readFileSync('$CONFIG_FILE','utf-8'));
-      console.log(c.hooks?.beforeSpecify !== false ? 'true' : 'false');
-    } catch { console.log('true'); }
-  " 2>/dev/null || echo "true")
+  if command -v node &> /dev/null; then
+    HOOK_ENABLED=$(node -e "
+      try {
+        const c = JSON.parse(require('fs').readFileSync('$CONFIG_FILE','utf-8'));
+        console.log(c.hooks?.beforeSpecify !== false ? 'true' : 'false');
+      } catch { console.log('true'); }
+    " 2>/dev/null || echo "true")
+  else
+    echo "[squad-bridge] WARNING: Node.js not found — cannot parse config, defaulting to hook enabled."
+    HOOK_ENABLED="true"
+  fi
   if [ "$HOOK_ENABLED" = "false" ]; then
     exit 0
   fi
@@ -32,7 +37,7 @@ echo "[squad-bridge] Injecting Squad context into ${SPEC_DIR}..."
 if command -v squask &> /dev/null; then
   squask context "$SPEC_DIR" --quiet 2>/dev/null || {
     echo "[squad-bridge] WARNING: Context injection failed — continuing without Squad context."
-    exit 0
+    exit 1
   }
   echo "[squad-bridge] Squad context injected successfully."
 else


### PR DESCRIPTION
Follow-up fixes for PR #315 review rejection.

- Restructures config check order (Node.js availability before config parsing)
- Exits non-zero on squask command failures
- Consistent pattern across all 3 hook templates

Fixes #311, #312, #313